### PR TITLE
sdkDir returns null if unable to locate Dart SDK

### DIFF
--- a/lib/grinder_utils.dart
+++ b/lib/grinder_utils.dart
@@ -12,7 +12,8 @@ import 'dart:io';
 import 'grinder.dart';
 
 /**
- * Return the path to the current Dart SDK.
+ * Return the path to the current Dart SDK. This will return `null` if we are
+ * unable to locate the Dart SDK.
  */
 Directory get sdkDir {
   // look for --dart-sdk on the command line
@@ -27,8 +28,10 @@ Directory get sdkDir {
   }
 
   // look relative to the dart executable
-  // TODO: file a bug re: the path to the executable and the cwd
-  return new File(Platform.executable).parent.parent;
+  // TODO: file a bug re: the path to the executable and the cwd.
+  Directory maybeSdkDirectory = new File(Platform.executable).parent.parent;
+  return joinFile(maybeSdkDirectory, ['version']).existsSync() ?
+      maybeSdkDirectory : null;
 }
 
 File get dartVM => joinFile(sdkDir, ['bin', _execName('dart')]);

--- a/test/grinder_utils_test.dart
+++ b/test/grinder_utils_test.dart
@@ -3,13 +3,17 @@
 
 library grinder_utils_test;
 
+import 'dart:io';
+
 import 'package:grinder/grinder.dart';
 import 'package:unittest/unittest.dart';
 
 main() {
   group('grinder.utils', () {
     test('get sdkDir', () {
-      expect(sdkDir, isNotNull);
+      if (Platform.environment['DART_SDK'] != null) {
+        expect(sdkDir, isNotNull);
+      }
     });
   });
 }


### PR DESCRIPTION
This fixes the issue, https://github.com/dart-lang/spark/issues/329
I'm not sure if this change is acceptable. 
Thanks!

TEST=dart ./test/all.dart
