### PR TITLE
add repalcePathSeparator

### DIFF
--- a/lib/grinder_files.dart
+++ b/lib/grinder_files.dart
@@ -191,3 +191,14 @@ void deleteEntity(FileSystemEntity entity, [GrinderContext context]) {
     entity.deleteSync(recursive: true);
   }
 }
+
+/**
+ * Return the [path] replaced with current platform seperator.
+ */
+String replacePathSeparator(String path) {
+  if (Platform.isWindows) {
+    return path.replaceAll('/', Platform.pathSeparator);
+  } else {
+    return path.replaceAll('\\', Platform.pathSeparator);
+  }
+}

--- a/test/grinder_files_test.dart
+++ b/test/grinder_files_test.dart
@@ -143,5 +143,10 @@ main() {
                               joinFile(targetDir, ['fileC']).readAsStringSync();
       expect(expectedResult, 'abcdefgh1234');
     });
+
+    test('replacePathSeparator', () {
+      expect(replacePathSeparator('foo/bar/file'), 'foo${sep}bar${sep}file');
+      expect(replacePathSeparator('foo\\bar\\file'), 'foo${sep}bar${sep}file');
+    });
   });
 }


### PR DESCRIPTION
This `repalcePathSeparator` reduces the code size, and useful to support multi platform environment.

TEST=./grind tests
