### PR TITLE
Pass context to recursive calls

### DIFF
--- a/AUTHORS
+++ b/AUTHORS
@@ -5,3 +5,4 @@
 
 Google Inc.
 Sungguk Lim limasdf@gmail.com
+Adam Singer financeCoding@gmail.com

--- a/lib/grinder_files.dart
+++ b/lib/grinder_files.dart
@@ -174,9 +174,9 @@ void copyDirectory(Directory srcDir, Directory destDir, [GrinderContext context]
     String name = fileName(entity);
 
     if (entity is File) {
-      copyFile(entity, destDir);
+      copyFile(entity, destDir, context);
     } else {
-      copyDirectory(entity, joinDir(destDir, [name]));
+      copyDirectory(entity, joinDir(destDir, [name]), context);
     }
   }
 }


### PR DESCRIPTION
Noticed that not all copy operations are actually printed when using grinder in the spark project. Tests pass and `./grinder dartium` in Spark now prints out a bunch more. 
