### PR TITLE
deprecate the grinder entrypoint

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -4,7 +4,6 @@
 *.swp
 .buildlog
 .DS_Store
-.project
 .svn
 packages
 pubspec.lock
@@ -12,3 +11,4 @@ pubspec.lock
 .pub/
 docs/
 build/
+.settings/

--- a/.project
+++ b/.project
@@ -1,0 +1,27 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<projectDescription>
+	<name>grinder.dart</name>
+	<comment></comment>
+	<projects>
+	</projects>
+	<buildSpec>
+		<buildCommand>
+			<name>com.google.dart.tools.core.dartBuilder</name>
+			<arguments>
+			</arguments>
+		</buildCommand>
+	</buildSpec>
+	<natures>
+		<nature>com.google.dart.tools.core.dartNature</nature>
+	</natures>
+	<filteredResources>
+		<filter>
+			<id>1418560754574</id>
+			<name></name>
+			<type>30</type>
+			<matcher>
+				<id>com.google.dart.tools.core.packagesFolderMatcher</id>
+			</matcher>
+		</filter>
+	</filteredResources>
+</projectDescription>

--- a/bin/grind.dart
+++ b/bin/grind.dart
@@ -6,6 +6,35 @@
  */
 library grinder.grind;
 
-import 'grinder.dart' as g;
+import 'dart:io';
 
-void main(List args) => g.runScript('tool/grind.dart', args);
+void main(List args) => runScript('tool/grind.dart', args);
+
+void runScript(String script, List args) {
+  File file = new File(script);
+
+  if (!file.existsSync()) {
+    print("Error: expected to find '${script}' "
+        "relative to the current directory.");
+    exit(1);
+  }
+
+  List newArgs = [script]..addAll(args);
+  _runProcessAsync(Platform.isWindows ? 'dart.exe' : 'dart', newArgs);
+}
+
+void _runProcessAsync(String executable, List<String> arguments) {
+  Process.start(executable, arguments).then((Process process) {
+    process.stdout.listen((List<int> data) {
+      stdout.write(new String.fromCharCodes(data));
+    });
+
+    process.stderr.listen((List<int> data) {
+      stderr.write(new String.fromCharCodes(data));
+    });
+
+    return process.exitCode.then((int code) {
+      if (code != 0) exit(code);
+    });
+  });
+}

--- a/bin/grinder.dart
+++ b/bin/grinder.dart
@@ -2,38 +2,16 @@
 // governed by a BSD-style license that can be found in the LICENSE file.
 
 /**
- * Look for `tool/grinder.dart` relative to the current directory and run it.
+ * Look for `tool/grind.dart` relative to the current directory and run it.
  */
 library grinder.grinder;
 
-import 'dart:io';
+import 'grind.dart' as grind;
 
-void main(List args) => runScript('tool/grinder.dart', args);
+@deprecated
+void main(List args) {
+  print("The 'grinder' entrypoint is deprecated; please use the 'grind'.");
+  print('');
 
-void runScript(String script, List args) {
-  File file = new File(script);
-
-  if (!file.existsSync()) {
-    print("Error: expected to find a '${script}' script.");
-    exit(1);
-  }
-
-  List newArgs = [script]..addAll(args);
-  _runProcessAsync(Platform.isWindows ? 'dart.exe' : 'dart', newArgs);
-}
-
-void _runProcessAsync(String executable, List<String> arguments) {
-  Process.start(executable, arguments).then((Process process) {
-    process.stdout.listen((List<int> data) {
-      stdout.write(new String.fromCharCodes(data));
-    });
-
-    process.stderr.listen((List<int> data) {
-      stderr.write(new String.fromCharCodes(data));
-    });
-
-    return process.exitCode.then((int code) {
-      if (code != 0) exit(code);
-    });
-  });
+  grind.main(args);
 }

--- a/changelog.md
+++ b/changelog.md
@@ -1,5 +1,8 @@
 # grinder.dart changes
 
+## 0.6.4
+- deprecate the `grinder` entrypoint; users should start the tool with `grind`
+
 ## 0.6.2 (2014/11/13)
 
 - widen the version constraint on `quiver`
@@ -12,16 +15,17 @@
 
 The convenience API is now more terse:
 - the `defineTask()` method has been renamed to `task()`
-- instead of named parameters, the `task()` function now uses optional positional parameters
+- instead of named parameters, the `task()` function now uses optional
+  positional parameters
 
 Added two new entrypoint files in `bin/`: `grind.dart` and `grinder.dart`. These
 let you run grinder via:
 
     pub run grinder test
 
-They look for a cooresponding grinder script in the `tool` directory (`bin/grind.dart`
+They look for a corresponding grinder script in the `tool` directory (`bin/grind.dart`
 looks for `tool/grind.dart` and `bin/grinder.dart` looks for `tool/grinder.dart`).
-If they find a cooresponding script they run it in a new Dart VM process. This
+If they find a corresponding script they run it in a new Dart VM process. This
 means that projects will no longer have to have a `grind.sh` script in the root
 of each project.
 
@@ -37,6 +41,8 @@ dartanalyzer - `Analyzer` - was created.
 
 ## 0.5.7 (2014/07/28)
 
-- added `runProcessAsync()` and related async methods (such as `PubTools.buildAsync(...)`)
+- added `runProcessAsync()` and related async methods (such as 
+  `PubTools.buildAsync(...)`)
 - removed duplicated stack traces when the build fails with exceptions
-- throw an exception when running SDK binaries, and we are not able to locate the Dart SDK
+- throw an exception when running SDK binaries, and we are not able to locate
+  the Dart SDK


### PR DESCRIPTION
fix #50 

Deprecate the `grinder` entrypoint; it'll be removed in some future milestone.
