### PR TITLE
CopyFile uses File.copySync instead of File.writeAsBytesSync

### DIFF
--- a/lib/grinder_files.dart
+++ b/lib/grinder_files.dart
@@ -170,7 +170,7 @@ void copyFile(File srcFile, Directory destDir, [GrinderContext context]) {
       context.log('copying ${srcFile.path} to ${destDir.path}');
     }
     destDir.createSync(recursive: true);
-    destFile.writeAsBytesSync(srcFile.readAsBytesSync());
+    srcFile.copySync(destFile.path);
   }
 }
 


### PR DESCRIPTION
`copySync` cannot fully copy the permissions. See https://code.google.com/p/dart/issues/detail?id=21900
But `copySync` copy the 'execute' permission at least.

@devoncarew 
