### PR TITLE
work on testing for web apps

### DIFF
--- a/bin/test.dart
+++ b/bin/test.dart
@@ -1,0 +1,67 @@
+// Copyright 2015 Google. All rights reserved. Use of this source code is
+// governed by a BSD-style license that can be found in the LICENSE file.
+
+import 'dart:io';
+
+import 'package:grinder/grinder.dart';
+
+/**
+ * A small command-line utility to leverage the grinder APIs to make it easy to
+ * run CLI or web app tests.
+ */
+void main(List<String> args) {
+  if (args.length != 1) {
+    print(
+        'usage: pub global activate grinder:test <filepath>');
+    print(
+        '  where <filepath> is either a .dart file (for CLI tests), '
+        'or an .html file (for web tests).');
+    exit(1);
+  }
+
+  String path = args.first;
+
+  _GrinderContext context = new _GrinderContext();
+
+  if (path.endsWith('.dart')) {
+    if (path.contains(Platform.pathSeparator)) {
+      String directory = path.substring(0, path.indexOf(Platform.pathSeparator));
+      path = path.substring(path.indexOf(Platform.pathSeparator) + 1);
+      Tests.runCliTests(context, directory: directory, testFile: path);
+    } else {
+      Tests.runCliTests(context, testFile: path);
+    }
+  } else if (path.endsWith('.html')) {
+    if (path.contains(Platform.pathSeparator)) {
+      int index = path.indexOf(Platform.pathSeparator);
+      // Handle build/ specially.
+      if (path.startsWith('build/')) {
+        index = path.indexOf(Platform.pathSeparator, index + 1);
+      }
+      String directory = path.substring(0, index);
+      path = path.substring(index + 1);
+      Tests.runWebTests(context,directory: directory, htmlFile: path)
+          .then((_) => exit(0))
+          .catchError((e) => exit(1));
+    } else {
+      Tests.runWebTests(context, htmlFile: path)
+          .then((_) => exit(0))
+          .catchError((e) => exit(1));
+    }
+  } else {
+    print('unhandled file type: ${path}');
+    exit(1);
+  }
+}
+
+class _GrinderContext implements GrinderContext {
+  Grinder get grinder => null;
+  GrinderTask get task => null;
+
+  void log(String message) => print(message);
+
+  void fail(String message) {
+    print(message);
+    exit(1);
+  }
+}

--- a/example/ex2.dart
+++ b/example/ex2.dart
@@ -8,15 +8,11 @@ import 'dart:async';
 import 'package:grinder/grinder.dart';
 
 void main([List<String> args]) {
-  task('init', init);
+  task('init', defaultInit);
   task('build', build, ['init']);
   task('all', null, ['build']);
 
   startGrinder(args);
-}
-
-void init(GrinderContext context) {
-  context.log("I set things up");
 }
 
 Future build(GrinderContext context) {

--- a/lib/grinder.dart
+++ b/lib/grinder.dart
@@ -221,7 +221,7 @@ class GrinderContext {
       } else {
         return [line];
       }
-    });
+    }).toList();
     grinder.log("  ${lines.join('\n  ')}");
   }
 

--- a/lib/src/_mserve.dart
+++ b/lib/src/_mserve.dart
@@ -1,0 +1,57 @@
+// Copyright 2015 Google. All rights reserved. Use of this source code is
+// governed by a BSD-style license that can be found in the LICENSE file.
+
+/**
+ * A very lightweight web server.
+ *
+ * **Note:** This library will likely move out of the `grinder` package.
+ */
+library grinder.mserve;
+
+import 'dart:async';
+import 'dart:io';
+
+import 'package:http_server/http_server.dart';
+
+/**
+ * A very lightweight web server.
+ *
+ * **Note:** This library will likely move out of the `grinder` package.
+ */
+class MicroServer {
+  static Future<MicroServer> start({String path, int port: 8000}) {
+    if (path == null) path = '.';
+
+    return HttpServer.bind('0.0.0.0', port).then((server) {
+      return new MicroServer._(path, server);
+    });
+  }
+
+  final String _path;
+  final HttpServer _server;
+  final StreamController _errorController = new StreamController.broadcast();
+
+  MicroServer._(this._path, this._server) {
+    VirtualDirectory vDir = new VirtualDirectory(path);
+    vDir.allowDirectoryListing = true;
+    vDir.jailRoot = false;
+
+    runZoned(() {
+      _server.listen(
+          vDir.serveRequest,
+          onError: (e) => _errorController.add(e));
+    }, onError: (e) => _errorController.add(e));
+  }
+
+  String get host => _server.address.host;
+
+  String get path => _path;
+
+  int get port => _server.port;
+
+  String get urlBase => 'http://${host}:${port}/';
+
+  Stream get onError => _errorController.stream;
+
+  Future destroy() => _server.close();
+}

--- a/lib/src/_mserve_bin.dart
+++ b/lib/src/_mserve_bin.dart
@@ -1,0 +1,42 @@
+// Copyright 2015 Google. All rights reserved. Use of this source code is
+// governed by a BSD-style license that can be found in the LICENSE file.
+
+import 'dart:io';
+
+import 'package:args/args.dart';
+import 'package:grinder/src/_mserve.dart';
+
+void main(List<String> args) {
+  ArgParser parser = new ArgParser();
+
+  parser.addOption('port', defaultsTo: '8000', abbr: 'p',
+      help: 'the port to serve on');
+  parser.addFlag('help', abbr: 'h', negatable: false,
+      help: "show help");
+
+  ArgResults results = parser.parse(args);
+
+  if (results['help']) {
+    print('usage: mserve <options> <directory>');
+    print('');
+    print('options:');
+    print(parser.usage.replaceAll('\n\n', '\n'));
+
+    exit(0);
+  }
+
+  String dir = null;
+
+  if (results.rest.isNotEmpty) {
+    dir = results.rest.first;
+  }
+
+  int port = int.parse(results['port'], onError: (source) {
+    print('Unable to parse port parameter: ${source}.');
+    exit(1);
+  });
+
+  MicroServer.start(path: dir, port: port).then((MicroServer server) {
+    print('Serving ${server.path} on ${server.urlBase}');
+  });
+}

--- a/lib/src/_wip.dart
+++ b/lib/src/_wip.dart
@@ -1,0 +1,565 @@
+// Copyright 2015 Google. All rights reserved. Use of this source code is
+// governed by a BSD-style license that can be found in the LICENSE file.
+
+/**
+ * A library to connect to a Webkit Inspection Protocol server (like Chrome).
+ *
+ * **Note:** This library will likely move out of the `grinder` package.
+ */
+library grinder.wip;
+
+import 'dart:async';
+import 'dart:convert' show JSON;
+import 'dart:io';
+
+import 'utils.dart';
+
+// TODO: Rename from WIP - it's the 'Remote debugging protocol' now.
+
+/**
+ * A class to connect to a Chrome instance and reflect on its available tabs.
+ *
+ * This assumes the browser has been started with the `--remote-debugging-port`
+ * flag. The data is read from the `http://{host}:{port}/json` url.
+ *
+ * **Note:** This library will likely move out of the `grinder` package.
+ */
+class ChromeConnection {
+  String _url;
+
+  ChromeConnection(String host, [int port = 9222]) {
+    _url = 'http://${host}:${port}/json';
+  }
+
+  String get url => _url;
+
+  Future<List<ChromeTab>> getTabs() {
+    return httpGet(url).then((String str) {
+      List list = JSON.decode(str);
+      return list.map((m) => new ChromeTab.fromMap(m));
+    });
+  }
+
+  Future<ChromeTab> getTab(bool accept(ChromeTab tab), {Duration retryFor}) {
+    DateTime start = new DateTime.now();
+
+    // TODO: could switch to a repeated stream of events and a completer
+
+    var _retry = () => false;
+    if (retryFor != null) {
+      _retry = () => new DateTime.now().difference(start) < retryFor;
+    }
+
+    var _getTab;
+    _getTab = () {
+      return getTabs().then((tabs) {
+        tabs = tabs.where(accept);
+        if (!tabs.isEmpty) return tabs.first;
+        if (_retry()) {
+          return new Future.delayed(
+              new Duration(milliseconds: 25)).then((_) => _getTab());
+        }
+        return null;
+      }).catchError((e) {
+        if (_retry()) {
+          return new Future.delayed(
+              new Duration(milliseconds: 25)).then((_) => _getTab());
+        }
+        throw e;
+      });
+    };
+
+    return _getTab();
+  }
+}
+
+class ChromeTab {
+  final Map _map;
+
+  ChromeTab.fromMap(this._map);
+
+  String get description => _map['description'];
+  String get devtoolsFrontendUrl => _map['devtoolsFrontendUrl'];
+  String get faviconUrl => _map['faviconUrl'];
+
+  /// Ex. `E1999E8A-EE27-0450-9900-5BFF4C69CA83`.
+  String get id => _map['id'];
+
+  String get title => _map['title'];
+
+  /// Ex. `background_page`, `page`.
+  String get type => _map['type'];
+
+  String get url => _map['url'];
+
+  /// Ex. `ws://localhost:1234/devtools/page/4F98236D-4EB0-7C6C-5DD1-AF9B6BE4BC71`.
+  String get webSocketDebuggerUrl => _map['webSocketDebuggerUrl'];
+
+  bool get hasIcon => _map.containsKey('faviconUrl');
+  bool get isChromeExtension => url.startsWith('chrome-extension://');
+  bool get isBackgroundPage => type == 'background_page';
+
+  String toString() => url;
+}
+
+/**
+ * A Webkit Inspection Protocol (WIP) connection.
+ */
+class WipConnection {
+  /**
+   * The WebSocket URL.
+   */
+  final String url;
+
+  final WebSocket _ws;
+
+  int _nextId = 0;
+
+  WipConsole console;
+  WipDebugger debugger;
+  WipPage page;
+  WipRuntime runtime;
+
+  Map _domains = {};
+
+  Map<int, Completer> _completers = {};
+
+  StreamController<WipConnection> _closeController = new StreamController.broadcast();
+
+  static Future<WipConnection> connect(String url) {
+    return WebSocket.connect(url).then((socket) {
+      return new WipConnection._(url, socket);
+    });
+  }
+
+  WipConnection._(this.url, this._ws) {
+    console = new WipConsole(this);
+    debugger = new WipDebugger(this);
+    page = new WipPage(this);
+    runtime = new WipRuntime(this);
+
+    _ws.listen((data) {
+      _Event event = new _Event._fromMap(JSON.decode(data));
+
+      if (event.isNotification) {
+        _handleNotification(event);
+      } else {
+        _handleResponse(event);
+      }
+    }, onDone: _handleClose);
+  }
+
+  Stream<WipConnection> get onClose => _closeController.stream;
+
+  Future close() => _ws.close();
+
+  String toString() => url;
+
+  void _registerDomain(String domainId, WipDomain domain) {
+    _domains[domainId] = domain;
+  }
+
+  Future<_Event> _sendCommand(_Event event) {
+    Completer completer = new Completer();
+    event.id = _nextId++;
+    _completers[event.id] = completer;
+    _ws.add(event.toJson());
+    return completer.future;
+  }
+
+  void _handleNotification(_Event event) {
+    String domainId = event.method;
+    int index = domainId.indexOf('.');
+    if (index != -1) {
+      domainId = domainId.substring(0, index);
+    }
+    if (_domains.containsKey(domainId)) {
+      _domains[domainId]._handleNotification(event);
+    } else {
+      _log('unhandled event notification: ${event.method}');
+    }
+  }
+
+  void _handleResponse(_Event event) {
+    Completer completer = _completers.remove(event.id);
+
+    assert(completer != null);
+
+    if (event.hasError) {
+      completer.completeError(new WipError(event));
+    } else {
+      completer.complete(new WipResponse(event));
+    }
+  }
+
+  void _log(String str) {
+    print(str);
+  }
+
+  void _handleClose() {
+    _closeController.add(this);
+  }
+}
+
+abstract class WipObject {
+  final Map map;
+
+  WipObject(this.map);
+}
+
+class WipEvent extends WipObject {
+  WipEvent(Map map) : super(map);
+
+  String get method => map['method'];
+  Map get params => map['params'];
+
+  String toString() => '${method}()';
+}
+
+class WipError {
+  final int id;
+  final dynamic error;
+
+  WipError(_Event event) : id = event.id, error = event.error;
+
+  String toString() => '${error}';
+}
+
+class WipResponse {
+  final int id;
+  final Map result;
+
+  WipResponse(_Event event) : id = event.id, result = event.result;
+
+  String toString() => '${result}';
+}
+
+abstract class WipDomain {
+  Map<String, Function> _callbacks = {};
+
+  WipConnection connection;
+
+  WipDomain(this.connection);
+
+  void _register(String method, Function callback) {
+    _callbacks[method] = callback;
+  }
+
+  void _handleNotification(_Event event) {
+    Function f = _callbacks[event.method];
+    if (f != null) f(event);
+  }
+
+  Future<_Event> _sendSimpleCommand(String method) {
+    return connection._sendCommand(new _Event(method));
+  }
+
+  Future<_Event> _sendCommand(_Event event) => connection._sendCommand(event);
+}
+
+class WipConsole extends WipDomain {
+  StreamController<ConsoleMessageEvent> _message = new StreamController.broadcast();
+  StreamController _cleared = new StreamController.broadcast();
+
+  ConsoleMessageEvent _lastMessage;
+
+  WipConsole(WipConnection connection): super(connection) {
+    connection._registerDomain('Console', this);
+
+    _register('Console.messageAdded', _messageAdded);
+    _register('Console.messageRepeatCountUpdated', _messageRepeatCountUpdated);
+    _register('Console.messagesCleared', _messagesCleared);
+  }
+
+  Future enable() => _sendSimpleCommand('Console.enable');
+  Future disable() => _sendSimpleCommand('Console.disable');
+  Future clearMessages() => _sendSimpleCommand('Console.clearMessages');
+
+  Stream<ConsoleMessageEvent> get onMessage => _message.stream;
+  Stream get onCleared => _cleared.stream;
+
+  void _messageAdded(_Event event) {
+    _lastMessage = new ConsoleMessageEvent(event);
+    _message.add(_lastMessage);
+  }
+
+  void _messageRepeatCountUpdated(_Event event) {
+    if (_lastMessage != null) {
+      _lastMessage.params['repeatCount'] = event.params['count'];
+      _message.add(_lastMessage);
+    }
+  }
+
+  void _messagesCleared(_Event event) {
+    _lastMessage = null;
+    _cleared.add(null);
+  }
+}
+
+class WipDebugger extends WipDomain {
+  StreamController _pausedController = new StreamController.broadcast();
+  StreamController _resumedController = new StreamController.broadcast();
+
+  Map<String, WipScript> _scripts = {};
+
+  WipDebugger(WipConnection connection): super(connection) {
+    connection._registerDomain('Debugger', this);
+
+    // TODO:
+    //_register('Debugger.breakpointResolved', _breakpointResolved);
+    _register('Debugger.globalObjectCleared', _globalObjectCleared);
+    _register('Debugger.paused', _paused);
+    _register('Debugger.resumed', _resumed);
+    //_register('Debugger.scriptFailedToParse', _scriptFailedToParse);
+    _register('Debugger.scriptParsed', _scriptParsed);
+  }
+
+  Future enable() => _sendSimpleCommand('Debugger.enable');
+  Future disable() => _sendSimpleCommand('Debugger.disable');
+
+  Future<String> getScriptSource(String scriptId) {
+    return _sendCommand(new _Event(
+        'Debugger.getScriptSource', {'scriptId': scriptId})).then((_Event event) {
+      return event.result['scriptSource'];
+    });
+  }
+
+  Future pause() => _sendSimpleCommand('Debugger.pause');
+  Future resume() => _sendSimpleCommand('Debugger.resume');
+
+  Future stepInto() => _sendSimpleCommand('Debugger.stepInto');
+  Future stepOut() => _sendSimpleCommand('Debugger.stepOut');
+  Future stepOver() => _sendSimpleCommand('Debugger.stepOver');
+
+  /**
+   * State should be one of "all", "none", or "uncaught".
+   */
+  Future setPauseOnExceptions(String state) {
+    var event = new _Event('Debugger.setPauseOnExceptions', {'state': state});
+    return connection._sendCommand(event);
+  }
+
+  Stream get onPaused => _pausedController.stream;
+  Stream get onResumed => _resumedController.stream;
+
+  WipScript getScript(String scriptId) => _scripts[scriptId];
+
+  void _globalObjectCleared(_Event event) {
+    _scripts.clear();
+  }
+
+  void _paused(_Event event) {
+    _pausedController.add(new DebuggerPausedEvent(event));
+  }
+
+  void _resumed(_Event event) {
+    _resumedController.add(null);
+  }
+
+  void _scriptParsed(_Event event) {
+    WipScript script = new WipScript(event.params);
+    _scripts[script.scriptId] = script;
+    print(script);
+  }
+}
+
+class WipPage extends WipDomain {
+  WipPage(WipConnection connection): super(connection) {
+    connection._registerDomain('Page', this);
+
+    // TODO:
+    // Page.loadEventFired
+    // Page.domContentEventFired
+  }
+
+  Future enable() => _sendSimpleCommand('Page.enable');
+  Future disable() => _sendSimpleCommand('Page.disable');
+
+  Future navigate(String url) {
+    return connection._sendCommand(new _Event('Page.navigate', {'url': url}));
+  }
+
+  Future reload({bool ignoreCache, String scriptToEvaluateOnLoad}) {
+    _Event event = new _Event('Page.navigate');
+
+    if (ignoreCache != null) {
+      event.addParam('ignoreCache', ignoreCache);
+    }
+
+    if (scriptToEvaluateOnLoad != null) {
+      event.addParam('scriptToEvaluateOnLoad', scriptToEvaluateOnLoad);
+    }
+
+    return connection._sendCommand(event);
+  }
+}
+
+class WipRuntime extends WipDomain {
+  WipRuntime(WipConnection connection): super(connection) {
+    connection._registerDomain('Page', this);
+  }
+}
+
+/**
+ * See [WipConsole.onMessage].
+ */
+class ConsoleMessageEvent extends WipEvent {
+  ConsoleMessageEvent(_Event event): super(event.map);
+
+  Map get _message => params['message'];
+
+  String get text => _message['text'];
+  String get level => _message['level'];
+  String get url => _message['url'];
+  int get repeatCount => _message['repeatCount'];
+
+  Iterable<WipCallFrame> getStackTrace() {
+    if (_message.containsKey('stackTrace')) {
+      return params['stackTrace'].map((frame) => new WipConsoleCallFrame(frame));
+    } else {
+      return [];
+    }
+  }
+
+  String toString() => text;
+}
+
+class WipConsoleCallFrame extends WipObject {
+  WipConsoleCallFrame(Map m): super(m);
+
+  int get columnNumber => map['columnNumber'];
+  String get functionName => map['functionName'];
+  int get lineNumber => map['lineNumber'];
+  String get scriptId => map['scriptId'];
+  String get url => map['url'];
+}
+
+class DebuggerPausedEvent extends WipEvent {
+  DebuggerPausedEvent(_Event event): super(event.map);
+
+  String get reason => params['reason'];
+  Object get data => params['data'];
+
+  Iterable<WipCallFrame> getCallFrames() {
+    return params['callFrames'].map((frame) => new WipCallFrame(frame));
+  }
+
+  String toString() => 'paused: ${reason}';
+}
+
+class ScriptParsedEvent extends WipEvent {
+  ScriptParsedEvent(Map params): super(params);
+
+  String get scriptId => params['scriptId'];
+  String get url => params['url'];
+  int get startLine => params['startLine'];
+  int get startColumn => params['startColumn'];
+  int get endLine => params['endLine'];
+  int get endColumn => params['endColumn'];
+  bool get isContentScript => params['isContentScript'];
+  String get sourceMapURL => params['sourceMapURL'];
+}
+
+class WipCallFrame extends WipObject {
+  WipCallFrame(Map params): super(params);
+
+  String get callFrameId => map['callFrameId'];
+  String get functionName => map['functionName'];
+  WipLocation get location => new WipLocation(map['location']);
+  WipRemoteObject get thisObject => new WipRemoteObject(map['this']);
+
+  Iterable<WipScope> getScopeChain() {
+    return map['scopeChain'].map((scope) => new WipScope(scope));
+  }
+
+  String toString() => '[${functionName}]';
+}
+
+class WipLocation extends WipObject {
+  WipLocation(Map params): super(params);
+
+  int get columnNumber => map['columnNumber'];
+  int get lineNumber => map['lineNumber'];
+  String get scriptId => map['scriptId'];
+
+  String toString() => '[${scriptId}:${lineNumber}:${columnNumber}]';
+}
+
+class WipScript extends WipObject {
+  WipScript(Map m): super(m);
+
+  String get scriptId => map['scriptId'];
+  String get url => map['url'];
+  int get startLine => map['startLine'];
+  int get startColumn => map['startColumn'];
+  int get endLine => map['endLine'];
+  int get endColumn => map['endColumn'];
+  bool get isContentScript => map['isContentScript'];
+  String get sourceMapURL => map['sourceMapURL'];
+
+  String toString() => '[script ${scriptId}: ${url}]';
+}
+
+class WipScope extends WipObject {
+  WipScope(Map params): super(params);
+
+  // "catch", "closure", "global", "local", "with"
+  String get scope => map['scope'];
+
+  /**
+   * Object representing the scope. For global and with scopes it represents the
+   * actual object; for the rest of the scopes, it is artificial transient
+   * object enumerating scope variables as its properties.
+   */
+  WipRemoteObject get object => new WipRemoteObject(map['object']);
+}
+
+class WipRemoteObject extends WipObject {
+  WipRemoteObject(Map map): super(map);
+
+  String get className => map['className'];
+  String get description => map['description'];
+  String get objectId => map['objectId'];
+  String get subtype => map['subtype'];
+  String get type => map['type'];
+  Object get value => map['value'];
+}
+
+class _Event {
+  final Map map;
+
+  _Event(String method, [Map params]) : map = {} {
+    map['method'] = method;
+
+    if (params != null) {
+      map['params'] = params;
+    }
+  }
+
+  _Event._fromMap(this.map);
+
+  String get method => map['method'];
+
+  int get id => map['id'];
+
+  set id(int value) {
+    map['id'] = value;
+  }
+
+  bool get isNotification => !map.containsKey('id');
+
+  bool get hasError => map.containsKey('error');
+  Object get error => map['error'];
+
+  Map get result => map['result'];
+
+  Map get params => map['params'];
+
+  void addParam(String key, Object value) {
+    map[key] = value;
+  }
+
+  String toJson() => JSON.encode(map);
+
+  String toString() => isNotification ? '${method}()' : '${method}() [${id}]';
+}

--- a/lib/src/webtest.dart
+++ b/lib/src/webtest.dart
@@ -1,0 +1,82 @@
+// Copyright 2015 Google. All rights reserved. Use of this source code is
+// governed by a BSD-style license that can be found in the LICENSE file.
+
+/**
+ * A `unittest` test configuration that logs the test progress and results to
+ * the browser's console log. This makes the test status information available
+ * to external test drivers.
+ */
+library grinder.webtest;
+
+import 'package:unittest/html_config.dart';
+import 'package:unittest/unittest.dart';
+
+/**
+ * A `unittest` test configuration that logs the test progress and results to
+ * the browser's console log.
+ */
+class WebTestConfiguration extends HtmlConfiguration {
+  /**
+   * Call this before defining tests.
+   */
+  static void setupTestEnvironment(
+      {Duration timeout: const Duration(seconds: 30)}) {
+    unittestConfiguration = new WebTestConfiguration(timeout: timeout);
+  }
+
+  WebTestConfiguration({Duration timeout}) : super(false) {
+    if (timeout != null) {
+      this.timeout = timeout;
+    }
+  }
+
+  void onStart() {
+    super.onStart();
+
+    _log('\nStarting tests\n--------------');
+  }
+
+  void onTestStart(TestCase testCase) {
+    super.onTestStart(testCase);
+
+    _log('${testCase}:');
+  }
+
+  void onTestResult(TestCase testCase) {
+    super.onTestResult(testCase);
+
+    _log('${testCase}');
+  }
+
+  void onSummary(int passed, int failed, int errors, List<TestCase> results,
+        String uncaughtError) {
+    _log('\nTest summary\n------------');
+
+    results.forEach((TestCase result) {
+      if (!result.passed) {
+        StringBuffer buf = new StringBuffer();
+        buf.writeln('${result}');
+        buf.writeln(_indent('  ', result.message.trimRight()));
+        if (result.stackTrace != null) {
+          buf.writeln(_indent('  ', result.stackTrace.toString()));
+        }
+        _log(buf.toString());
+      }
+    });
+
+    if (failed + errors > 0) _log('\n');
+    _log('${passed} passed, ${failed} failed, ${errors} errors');
+
+    super.onSummary(passed, failed, errors, results, uncaughtError);
+  }
+
+  void onDone(bool success) {
+    _log('tests finished - ${success ? "passed" : "failed"}.');
+    super.onDone(success);
+  }
+
+  String _indent(String indent, String str) =>
+      str.split('\n').map((s) => '${indent}${s}').join('\n');
+
+  void _log(String message) => print(message.trimRight());
+}

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -11,10 +11,12 @@ environment:
 
 dependencies:
   args: '>=0.10.0 <0.13.0'
+  http_server: '>=0.9.0 <0.10.0'
   quiver: '>=0.18.0 <0.21.0'
   which: '>=0.1.2 <0.2.0'
 
 dev_dependencies:
+  browser: any
   unittest: any
 
 executables:

--- a/tool/grind.dart
+++ b/tool/grind.dart
@@ -1,12 +1,15 @@
 // Copyright 2013 Google. All rights reserved. Use of this source code is
 // governed by a BSD-style license that can be found in the LICENSE file.
 
+import 'dart:async';
+
 import 'package:grinder/grinder.dart';
 
 void main([List<String> args]) {
   task('init', init);
   task('analyze', analyze, ['init']);
   task('tests', tests, ['init']);
+  task('tests-web', testsWeb, ['init']);
 
   startGrinder(args);
 }
@@ -24,4 +27,12 @@ void analyze(GrinderContext context) {
 
 void tests(GrinderContext context) {
   Tests.runCliTests(context);
+}
+
+Future testsWeb(GrinderContext context) {
+  return Pub.buildAsync(context, directories: ['web']).then((_) {
+    return Tests.runWebTests(context, directory: 'build/web', htmlFile: 'web.html');
+  });
+
+//  return Tests.runWebTests(context, directory: 'web', htmlFile: 'web.html');
 }

--- a/web/web.dart
+++ b/web/web.dart
@@ -1,0 +1,38 @@
+// Copyright 2015 Google. All rights reserved. Use of this source code is
+// governed by a BSD-style license that can be found in the LICENSE file.
+
+library grinder.web_test;
+
+import 'dart:async';
+
+import 'package:grinder/src/webtest.dart';
+import 'package:unittest/unittest.dart';
+
+void main() {
+  // Set up the test environment.
+  WebTestConfiguration.setupTestEnvironment();
+
+  // Define the tests.
+  defineTests();
+}
+
+defineTests() {
+  group('fruit', () {
+    test('apples', () {
+      expect(1, 1);
+    });
+    test('oranges', () {
+      expect(1, 1);
+    });
+    test('short', () {
+      return new Future.delayed(new Duration(seconds: 1), () {
+        expect(1, 1);
+      });
+    });
+//    test('long', () {
+//      return new Future.delayed(new Duration(seconds: 45), () {
+//        expect(1, 1);
+//      });
+//    });
+  });
+}

--- a/web/web.html
+++ b/web/web.html
@@ -1,0 +1,17 @@
+<!DOCTYPE html>
+
+<!-- Copyright 2015 Google. All rights reserved. Use of this source code is
+     governed by a BSD-style license that can be found in the LICENSE file. -->
+
+<html>
+  <head>
+  	<meta charset="utf-8">
+  	<meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <title>Grinder Sample Web Tests</title>
+  </head>
+
+  <body>
+    <script type="application/dart" src="web.dart"></script>
+    <script src="packages/browser/dart.js"></script>
+  </body>
+</html>


### PR DESCRIPTION
Add the ability to drive web tests from a grinder script. This will use either chrome or dartium, depending on whether the files under test are in `test/` or `build/test`.