### PR TITLE
simplify the file manipulation code a bit

### DIFF
--- a/lib/grinder_files.dart
+++ b/lib/grinder_files.dart
@@ -14,6 +14,8 @@ import 'package:glob/glob.dart';
 
 import 'grinder.dart';
 
+final String _sep = Platform.pathSeparator;
+
 // TODO: add files to a set
 
 // TODO: union sets?
@@ -97,13 +99,113 @@ class FileSet {
   }
 }
 
+abstract class Path {
+  factory Path(FileSystemEntity entity) => new _EntityPath(entity);
+  factory Path.str(String p) => new _StringPath(p);
+
+  Path._();
+
+  String get name;
+
+  String get path;
+
+  bool get isDirectory;
+
+  bool get exists;
+
+  FileSystemEntity get entity;
+
+  void copyPath(Directory destDir) => copy(entity, destDir);
+
+  void deletePath() => delete(entity);
+
+  Path join([arg0, String arg1, String arg2, String arg3, String arg4,
+    String arg5, String arg6, String arg7, String arg8, String arg9]) {
+    List args = [];
+
+    if (arg0 is List) {
+      args = arg0;
+    } else if (arg0 is String) {
+      _addNonNull(args, arg0);
+      _addNonNull(args, arg1);
+      _addNonNull(args, arg2);
+      _addNonNull(args, arg3);
+      _addNonNull(args, arg4);
+      _addNonNull(args, arg5);
+      _addNonNull(args, arg6);
+      _addNonNull(args, arg7);
+      _addNonNull(args, arg8);
+      _addNonNull(args, arg9);
+    }
+
+    if (args.isEmpty) {
+      return this;
+    } else {
+      return new Path.str('${path}${_sep}${args.join(_sep)}');
+    }
+  }
+
+  File returnAsFile() => new File(path);
+
+  Directory returnAsDirectory() => new Directory(path);
+
+  String toString() => path;
+}
+
+class _EntityPath extends Path {
+  final FileSystemEntity _entity;
+
+  _EntityPath(this._entity) : super._();
+
+  FileSystemEntity get entity => _entity;
+
+  bool get exists => _entity.existsSync();
+
+  bool get isDirectory => _entity is Directory;
+
+  String get name => fileName(_entity);
+
+  String get path => _entity.path;
+}
+
+class _StringPath extends Path {
+  final String _path;
+
+  _StringPath(this._path) : super._();
+
+  FileSystemEntity get entity {
+    final FileSystemEntityType type = FileSystemEntity.typeSync(_path);
+
+    if (type == FileSystemEntityType.FILE) {
+      return new File(_path);
+    } else if (type == FileSystemEntityType.DIRECTORY) {
+      return new Directory(_path);
+    } else if (type == FileSystemEntityType.LINK) {
+      return new Link(_path);
+    } else {
+      return null;
+    }
+  }
+
+  bool get exists =>
+      FileSystemEntity.typeSync(_path) != FileSystemEntityType.NOT_FOUND;
+
+  bool get isDirectory => FileSystemEntity.isDirectorySync(_path);
+
+  String get name {
+    int index = _path.lastIndexOf(_sep);
+    return index != -1 ? _path.substring(index + 1) : null;
+  }
+
+  String get path => _path;
+}
+
 /**
  * Return the last segment of the file path.
  */
 String fileName(FileSystemEntity entity) {
   String name = entity.path;
-  int index = name.lastIndexOf(Platform.pathSeparator);
-
+  int index = name.lastIndexOf(_sep);
   return (index != -1 ? name.substring(index + 1) : name);
 }
 
@@ -122,19 +224,18 @@ String fileExt(FileSystemEntity entity) {
  */
 String baseName(FileSystemEntity entity) {
   String name = entity.path;
-  int index = name.lastIndexOf(Platform.pathSeparator);
-
+  int index = name.lastIndexOf(_sep);
   return (index != -1 ? name.substring(0, index) : null);
 }
 
 File joinFile(Directory dir, List<String> files) {
-  String pathFragment = files.join(Platform.pathSeparator);
-  return new File("${dir.path}${Platform.pathSeparator}${pathFragment}");
+  String pathFragment = files.join(_sep);
+  return new File("${dir.path}${_sep}${pathFragment}");
 }
 
 Directory joinDir(Directory dir, List<String> files) {
-  String pathFragment = files.join(Platform.pathSeparator);
-  return new Directory("${dir.path}${Platform.pathSeparator}${pathFragment}");
+  String pathFragment = files.join(_sep);
+  return new Directory("${dir.path}${_sep}${pathFragment}");
 }
 
 /**
@@ -142,10 +243,10 @@ Directory joinDir(Directory dir, List<String> files) {
  * given path to a platform dependent path.
  */
 File getFile(String path) {
-  if (Platform.pathSeparator == '/') {
+  if (_sep == '/') {
     return new File(path);
   } else {
-    return new File(path.replaceAll('/', Platform.pathSeparator));
+    return new File(path.replaceAll('/', _sep));
   }
 }
 
@@ -154,43 +255,48 @@ File getFile(String path) {
  * given path to a platform dependent path.
  */
 Directory getDir(String path) {
-  if (Platform.pathSeparator == '/') {
+  if (_sep == '/') {
     return new Directory(path);
   } else {
-    return new Directory(path.replaceAll('/', Platform.pathSeparator));
+    return new Directory(path.replaceAll('/', _sep));
   }
 }
 
-void copyFile(File srcFile, Directory destDir, [GrinderContext context]) {
-  File destFile = joinFile(destDir, [fileName(srcFile)]);
-
-  if (!destFile.existsSync() ||
-      srcFile.lastModifiedSync() != destFile.lastModifiedSync()) {
+void copy(FileSystemEntity entity, Directory destDir, [GrinderContext context]) {
+  if (entity is Directory) {
     if (context != null) {
-      context.log('copying ${srcFile.path} to ${destDir.path}');
+      context.log('copying ${entity.path} to ${destDir.path}');
     }
-    destDir.createSync(recursive: true);
-    srcFile.copySync(destFile.path);
+
+    for (FileSystemEntity entity in entity.listSync()) {
+      String name = fileName(entity);
+
+      if (entity is File) {
+        copy(entity, destDir);
+      } else {
+        copy(entity, joinDir(destDir, [name]));
+      }
+    }
+  } else if (entity is File) {
+    File destFile = joinFile(destDir, [fileName(entity)]);
+
+    if (!destFile.existsSync() ||
+        entity.lastModifiedSync() != destFile.lastModifiedSync()) {
+      if (context != null) {
+        context.log('copying ${entity.path} to ${destDir.path}');
+      }
+      destDir.createSync(recursive: true);
+      entity.copySync(destFile.path);
+    }
+  } else {
+    throw new StateError('unexpected type: ${entity.runtimeType}');
   }
 }
 
-void copyDirectory(Directory srcDir, Directory destDir, [GrinderContext context]) {
-  if (context != null) {
-    context.log('copying ${srcDir.path} to ${destDir.path}');
-  }
-
-  for (FileSystemEntity entity in srcDir.listSync()) {
-    String name = fileName(entity);
-
-    if (entity is File) {
-      copyFile(entity, destDir);
-    } else {
-      copyDirectory(entity, joinDir(destDir, [name]));
-    }
-  }
-}
-
-void deleteEntity(FileSystemEntity entity, [GrinderContext context]) {
+/**
+ * Delete the given file entity reference.
+ */
+void delete(FileSystemEntity entity, [GrinderContext context]) {
   if (entity.existsSync()) {
     if (context != null) {
       context.log('deleting ${entity.path}');
@@ -198,4 +304,24 @@ void deleteEntity(FileSystemEntity entity, [GrinderContext context]) {
 
     entity.deleteSync(recursive: true);
   }
+}
+
+
+@Deprecated('deprecated in favor of copy()')
+void copyFile(File srcFile, Directory destDir, [GrinderContext context]) {
+  copy(srcFile, destDir, context);
+}
+
+@Deprecated('deprecated in favor of copy()')
+void copyDirectory(Directory srcDir, Directory destDir, [GrinderContext context]) {
+  copy(srcDir, destDir, context);
+}
+
+@Deprecated('deprecated in favor of delete()')
+void deleteEntity(FileSystemEntity entity, [GrinderContext context]) {
+  delete(entity, context);
+}
+
+_addNonNull(List args, String arg) {
+  if (arg != null) args.add(arg);
 }

--- a/lib/grinder_tools.dart
+++ b/lib/grinder_tools.dart
@@ -152,7 +152,7 @@ void defaultInit(GrinderContext context) {
  */
 void defaultClean(GrinderContext context) {
   // Delete the `build/` dir.
-  deleteEntity(BUILD_DIR, context);
+  delete(BUILD_DIR, context);
 }
 
 /**

--- a/test/grinder_files_test.dart
+++ b/test/grinder_files_test.dart
@@ -162,7 +162,6 @@ main() {
 
   group('grinder.files Path', () {
     Directory temp;
-    final String sep = Platform.pathSeparator;
 
     setUp(() {
       temp = Directory.systemTemp.createTempSync();
@@ -177,7 +176,7 @@ main() {
       expect(p.exists, true);
       expect(p.isDirectory, true);
 
-      File tempFile = p.join('temp.txt').returnAsFile();
+      File tempFile = p.join('temp.txt').asFile;
       tempFile.writeAsStringSync('foo\n', flush: true);
 
       Path p2 = new Path(tempFile);
@@ -187,17 +186,36 @@ main() {
     });
 
     test('Path.str', () {
-      Path p = new Path.str(temp.path);
-      expect(p.exists, true);
-      expect(p.isDirectory, true);
+      Path parent = new Path(temp.path);
+      expect(parent.exists, true);
+      expect(parent.isDirectory, true);
 
-      File tempFile = p.join('temp.txt').returnAsFile();
+      File tempFile = parent.join('temp.txt').asFile;
       tempFile.writeAsStringSync('foo\n', flush: true);
 
-      Path p2 = new Path.str(tempFile.path);
+      Path p2 = new Path(tempFile.path);
       expect(p2.exists, true);
       expect(p2.isDirectory, false);
       expect(p2.name, 'temp.txt');
+    });
+
+    test('Path copy', () {
+      Path parent = new Path(temp.path);
+      Path file = parent.join('temp.txt');
+      file.asFile.writeAsStringSync('foo\n', flush: true);
+      Path childDir = parent.join('child_dir')..createDirectory();
+      Path copied = file.copy(childDir);
+      expect(copied.exists, true);
+      expect(copied.path, endsWith('temp.txt'));
+    });
+
+    test('Path delete', () {
+      Path parent = new Path(temp.path);
+      Path file = parent.join('temp.txt');
+      file.asFile.writeAsStringSync('foo\n', flush: true);
+      expect(file.exists, true);
+      file.delete();
+      expect(file.exists, false);
     });
   });
 }

--- a/test/grinder_files_test.dart
+++ b/test/grinder_files_test.dart
@@ -136,7 +136,7 @@ main() {
       source.writeAsStringSync('abcdABCD');
 
       Directory targetDir = joinDir(temp, ['targetDir']);
-      copyFile(source, targetDir);
+      copy(source, targetDir);
 
       File expectedFile = joinFile(targetDir, ['${tempFileName}']);
       expect(expectedFile.readAsStringSync(), 'abcdABCD');
@@ -151,12 +151,53 @@ main() {
       joinFile(sourceDir, ['fileC']).writeAsStringSync('1234');
 
       Directory targetDir = joinDir(temp,['target']);
-      copyDirectory(sourceDir, targetDir);
+      copy(sourceDir, targetDir);
 
       String expectedResult = joinFile(targetDir, ['fileA']).readAsStringSync() +
                               joinFile(targetDir, ['fileB']).readAsStringSync() +
                               joinFile(targetDir, ['fileC']).readAsStringSync();
       expect(expectedResult, 'abcdefgh1234');
+    });
+  });
+
+  group('grinder.files Path', () {
+    Directory temp;
+    final String sep = Platform.pathSeparator;
+
+    setUp(() {
+      temp = Directory.systemTemp.createTempSync();
+    });
+
+    tearDown(() {
+      temp.deleteSync(recursive: true);
+    });
+
+    test('Path.entity', () {
+      Path p = new Path(temp);
+      expect(p.exists, true);
+      expect(p.isDirectory, true);
+
+      File tempFile = p.join('temp.txt').returnAsFile();
+      tempFile.writeAsStringSync('foo\n', flush: true);
+
+      Path p2 = new Path(tempFile);
+      expect(p2.exists, true);
+      expect(p2.isDirectory, false);
+      expect(p2.name, 'temp.txt');
+    });
+
+    test('Path.str', () {
+      Path p = new Path.str(temp.path);
+      expect(p.exists, true);
+      expect(p.isDirectory, true);
+
+      File tempFile = p.join('temp.txt').returnAsFile();
+      tempFile.writeAsStringSync('foo\n', flush: true);
+
+      Path p2 = new Path.str(tempFile.path);
+      expect(p2.exists, true);
+      expect(p2.isDirectory, false);
+      expect(p2.name, 'temp.txt');
     });
   });
 }

--- a/test/grinder_files_test.dart
+++ b/test/grinder_files_test.dart
@@ -161,57 +161,75 @@ main() {
   });
 
   group('grinder.files Path', () {
-    Directory temp;
+    Path temp;
 
     setUp(() {
-      temp = Directory.systemTemp.createTempSync();
+      temp = Path.createSystemTemp();
     });
 
-    tearDown(() {
-      temp.deleteSync(recursive: true);
-    });
+    tearDown(() => temp.delete());
 
     test('Path.entity', () {
-      Path p = new Path(temp);
-      expect(p.exists, true);
-      expect(p.isDirectory, true);
+      Path dir = new Path(temp.entity);
+      expect(dir.exists, true);
+      expect(dir.isDirectory, true);
 
-      File tempFile = p.join('temp.txt').asFile;
-      tempFile.writeAsStringSync('foo\n', flush: true);
-
-      Path p2 = new Path(tempFile);
-      expect(p2.exists, true);
-      expect(p2.isDirectory, false);
-      expect(p2.name, 'temp.txt');
+      Path file = dir.join('temp.txt');
+      file.asFile.writeAsStringSync('foo\n', flush: true);
+      expect(file.exists, true);
+      expect(file.isDirectory, false);
+      expect(file.name, 'temp.txt');
     });
 
     test('Path.str', () {
-      Path parent = new Path(temp.path);
-      expect(parent.exists, true);
-      expect(parent.isDirectory, true);
+      Path dir = new Path(temp.path);
+      expect(dir.exists, true);
+      expect(dir.isDirectory, true);
 
-      File tempFile = parent.join('temp.txt').asFile;
-      tempFile.writeAsStringSync('foo\n', flush: true);
+      Path file = dir.join('temp.txt');
+      file.asFile.writeAsStringSync('foo\n', flush: true);
+      expect(file.exists, true);
+      expect(file.isDirectory, false);
+      expect(file.name, 'temp.txt');
 
-      Path p2 = new Path(tempFile.path);
-      expect(p2.exists, true);
-      expect(p2.isDirectory, false);
-      expect(p2.name, 'temp.txt');
+      expect(new Path(dir.path + Platform.pathSeparator).path, dir.path);
     });
 
-    test('Path copy', () {
-      Path parent = new Path(temp.path);
-      Path file = parent.join('temp.txt');
+    test('cwd', () {
+      expect(Path.cwd, isNotNull);
+      expect(Path.cwd.isDirectory, true);
+    });
+
+    test('parent', () {
+      expect(temp.parent, isNotNull);
+      expect(temp.parent.isDirectory, true);
+
+      expect(Path.cwd.parent, isNotNull);
+      expect(Path.cwd.parent.path, isNotEmpty);
+      expect(Path.cwd.parent.parent, isNotNull);
+
+      Path root = new Path('/');
+      expect(root.exists, true);
+      expect(root.parent, isNotNull);
+      expect(root.parent.parent, isNotNull);
+    });
+
+//    test('absolute', () {
+//      expect(Path.cwd, notEquals(Path.cwd.absolute));
+//      expect(Path.cwd.absolute.absolute, Path.cwd.absolute);
+//    });
+
+    test('copy', () {
+      Path file = temp.join('temp.txt');
       file.asFile.writeAsStringSync('foo\n', flush: true);
-      Path childDir = parent.join('child_dir')..createDirectory();
+      Path childDir = temp.join('child_dir')..createDirectory();
       Path copied = file.copy(childDir);
       expect(copied.exists, true);
       expect(copied.path, endsWith('temp.txt'));
     });
 
-    test('Path delete', () {
-      Path parent = new Path(temp.path);
-      Path file = parent.join('temp.txt');
+    test('delete', () {
+      Path file = temp.join('temp.txt');
       file.asFile.writeAsStringSync('foo\n', flush: true);
       expect(file.exists, true);
       file.delete();


### PR DESCRIPTION
partially address #36 

- `copyFile` and `copyDirectory` and deprecated in favor of a new `copy` method
- `deleteEntity` is deprecated in favor of a new `delete` method
- also added a new `Path` class, in order to experiment with an easier way to essentially add `name`, `copy`, and `delete` methods to file system entities