### PR TITLE
Enable testing on Windows via Appveyor CI

### DIFF
--- a/AUTHORS
+++ b/AUTHORS
@@ -9,3 +9,4 @@ Adam Singer <financeCoding@gmail.com>
 W. Brian Gourlie <bgourlie@gmail.com>
 Kenneth Endfinger <kaendfinger@gmail.com>
 Sean Eagan <seaneagan1@gmail.com>
+Guillermo López-Anglada <guillermo.lopez@outlook.com>

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -1,0 +1,11 @@
+# Copyright (c) 2014, Google Inc. Please see the AUTHORS file for details.
+# All rights reserved. Use of this source code is governed by a BSD-style
+# license that can be found in the LICENSE file.
+
+install:
+  - ps: .\tool\appveyor.ps1 install
+
+build: off
+
+test_script:
+  - ps: .\tool\appveyor.ps1 test

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -1,4 +1,4 @@
-# Copyright (c) 2014, Google Inc. Please see the AUTHORS file for details.
+# Copyright (c) 2015, Google Inc. Please see the AUTHORS file for details.
 # All rights reserved. Use of this source code is governed by a BSD-style
 # license that can be found in the LICENSE file.
 

--- a/readme.md
+++ b/readme.md
@@ -2,7 +2,12 @@
 
 A task based, dependency aware build system.
 
-[![Build Status](https://travis-ci.org/google/grinder.dart.svg?branch=master)](https://travis-ci.org/google/grinder.dart)
+**Plaform** | **Status**
+------------|------------
+Linux | [![Build Status](https://travis-ci.org/google/grinder.dart.svg?branch=master)](https://travis-ci.org/google/grinder.dart)
+OS X | -/-
+Windows | -/-
+
 [![Coverage Status](https://img.shields.io/coveralls/google/grinder.dart.svg)](https://coveralls.io/r/google/grinder.dart)
 
 ## Intro

--- a/tool/appveyor.ps1
+++ b/tool/appveyor.ps1
@@ -1,8 +1,18 @@
+# Copyright (c) 2014, Google Inc. Please see the AUTHORS file for details.
+# All rights reserved. Use of this source code is governed by a BSD-style
+# license that can be found in the LICENSE file.
+
 param([string]$action)
+
+function throw_if_process_failed {
+    param([string]$message)
+    if ($LASTEXITCODE -ne 0) { throw $message }
+}
 
 function install {
     start-filedownload https://storage.googleapis.com/dart-archive/channels/stable/release/latest/sdk/dartsdk-windows-x64-release.zip
     7z.exe x dartsdk-windows-x64-release.zip -oc:\ | select-string "^Extracting" -notmatch
+    throw_if_process_failed "could not extract sdk"
 }
 
 function test {
@@ -12,7 +22,7 @@ function test {
     pub global activate tuneup
     # Verify that the libraries are error free.
     pub global run tuneup check --ignore-infos
-    if ($LASTEXITCODE -ne 0) { throw "libraries have errors" }
+    throw_if_process_failed "libraries have errors"
 
     # Run the tests.
     dart test/all.dart 

--- a/tool/appveyor.ps1
+++ b/tool/appveyor.ps1
@@ -1,0 +1,26 @@
+param([string]$action)
+
+function install {
+    start-filedownload https://storage.googleapis.com/dart-archive/channels/stable/release/latest/sdk/dartsdk-windows-x64-release.zip
+    7z.exe x dartsdk-windows-x64-release.zip -oc:\ | select-string "^Extracting" -notmatch
+}
+
+function test {
+    $env:PATH = "c:\dart-sdk\bin;$env:PATH"
+
+    # Install global tools.
+    pub global activate tuneup
+    # Verify that the libraries are error free.
+    pub global run tuneup check --ignore-infos
+    if ($LASTEXITCODE -ne 0) { throw "libraries have errors" }
+
+    # Run the tests.
+    dart test/all.dart 
+    # Verify that the generated grind script analyzes well.
+    dart tool/grind.dart analyze-init
+}
+
+switch ($action) {
+    "install" { install }
+    "test" { test }
+}

--- a/tool/appveyor.ps1
+++ b/tool/appveyor.ps1
@@ -1,4 +1,4 @@
-# Copyright (c) 2014, Google Inc. Please see the AUTHORS file for details.
+# Copyright (c) 2015, Google Inc. Please see the AUTHORS file for details.
 # All rights reserved. Use of this source code is governed by a BSD-style
 # license that can be found in the LICENSE file.
 


### PR DESCRIPTION
I've added config files to run tests through Appveyor.

I'm not familiar with the tools used by grinder, so please take a look a the current output:

https://ci.appveyor.com/project/guillermooo/grinder-dart

On my local Win PC, I got tests to pass, so I'm probably missing something.