### PR TITLE
dogfood grinder on our bots; write a wrapper around pub tools

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,2 +1,2 @@
 language: dart
-script: ./tool/travis.sh
+script: dart tool/grind.dart buildbot

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -11,7 +11,4 @@ install:
 build: off
 
 test_script:
-  - pub global activate tuneup
-  - pub global run tuneup check --ignore-infos
-  - dart -c test\all.dart
-  - dart tool\grind.dart analyze-init
+  - dart tool\grind.dart buildbot

--- a/bin/init.dart
+++ b/bin/init.dart
@@ -37,14 +37,14 @@ import 'package:grinder/grinder.dart';
 main(args) => grind(args);
 
 @Task()
-init(GrinderContext context) => defaultInit(context);
+init() => defaultInit();
 
 @DefaultTask()
 @Depends(init)
-build(GrinderContext context) {
-  Pub.build(context);
+build() {
+  Pub.build();
 }
 
 @Task()
-clean(GrinderContext context) => defaultClean(context);
+clean() => defaultClean();
 ''';

--- a/lib/src/cli.dart
+++ b/lib/src/cli.dart
@@ -61,6 +61,8 @@ Future handleArgs(List<String> args) {
 
 ArgParser createArgsParser() {
   ArgParser parser = new ArgParser();
+  parser.addOption('dart-sdk',
+      help: 'set the location of the Dart SDK');
   parser.addFlag('version', negatable: false,
       help: "print the version of grinder");
   parser.addFlag('help', abbr: 'h', negatable: false,

--- a/test/grinder_tools_test.dart
+++ b/test/grinder_tools_test.dart
@@ -59,5 +59,13 @@ main() {
       Pub.global.isInstalled('foo');
       expect(context.isFailed, false);
     });
+
+    test('PubApplication', () {
+      PubApplication grinder = new PubApplication('grinder');
+      if (!grinder.isInstalled()) {
+        grinder.activate();
+        expect(grinder.isInstalled(), true);
+      }
+    });
   });
 }


### PR DESCRIPTION
Fix #118; fix #71.

- write a wrapper (`PubApplication`) around a pub global activate tool
- dogfood grinder on our buildbot
- some work towards making it easier to debug a script using the editor's debugger