### PR TITLE
ensure we exit with a non-zero code on failures

### DIFF
--- a/lib/src/cli.dart
+++ b/lib/src/cli.dart
@@ -48,7 +48,7 @@ Future handleArgs(List<String> args) {
 
     return result.catchError((e, st) {
       if (st != null) {
-        print('\n${e}\n${st}');
+        print('\n${e}\n${cleanupStackTrace(st)}');
       } else {
         print('\n${e}');
       }
@@ -120,4 +120,22 @@ void printDeps(Grinder grinder) {
       }
     });
   }
+}
+
+String cleanupStackTrace(st) {
+  List<String> lines = '${st}'.trim().split('\n');
+
+  // Remove lines which are not useful to debugging script issues. With our move
+  // to using zones, the exceptions now have stacks 30 frames deep.
+  while (lines.isNotEmpty) {
+    String line = lines.last;
+
+    if (line.contains(' (dart:') || line.contains(' (package:grinder/')) {
+      lines.removeLast();
+    } else {
+      break;
+    }
+  }
+
+  return lines.join('\n').trim().replaceAll('<anonymous closure>', '<anon>');
 }

--- a/test/all.dart
+++ b/test/all.dart
@@ -3,15 +3,17 @@
 
 library all_test;
 
-import 'cli_test.dart' as cli_test;
+import 'src/cli_test.dart' as src_cli_test;
 import 'task_discovery/discover_tasks_test.dart' as discover_tasks_test;
+import 'cli_test.dart' as cli_test;
 import 'grinder_test.dart' as grinder_test;
 import 'grinder_files_test.dart' as grinder_files_test;
 import 'grinder_tools_test.dart' as grinder_tools_test;
 
 main() {
-  cli_test.main();
+  src_cli_test.main();
   discover_tasks_test.main();
+  cli_test.main();
   grinder_test.main();
   grinder_files_test.main();
   grinder_tools_test.main();

--- a/test/grinder_test.dart
+++ b/test/grinder_test.dart
@@ -175,15 +175,15 @@ main() {
       });
     });
 
-    test('Dont throw on fail', () {
+    test('throw on fail', () {
       Grinder grinder = new Grinder();
       grinder.addTask(new GrinderTask('i_throw', taskFunction: (GrinderContext context) {
         context.fail('boo');
       }));
 
-      return grinder.start(['i_throw']).catchError((e) {
-        fail("shouldn't throw");
-      });
+      return grinder.start(['i_throw']).then((e) {
+        fail("should throw");
+      }).catchError((e) => null);
     });
   });
 }

--- a/test/src/cli_test.dart
+++ b/test/src/cli_test.dart
@@ -1,0 +1,54 @@
+// Copyright 2015 Google. All rights reserved. Use of this source code is
+// governed by a BSD-style license that can be found in the LICENSE file.
+
+library grinder.src.cli_test;
+
+import 'package:grinder/src/cli.dart';
+import 'package:unittest/unittest.dart';
+
+main() {
+  group('cli', () {
+    test('cleanupStackTrace', () {
+      expect(cleanupStackTrace(_st), _stExpected);
+    });
+  });
+}
+
+final _st = '''
+#0      GrinderContext.fail (package:grinder/grinder.dart:131:5)
+#1      fail (package:grinder/grinder.dart:85:42)
+#2      analyze (file:///Users/devoncarew/projects/grinder.dart/tool/grind.dart:17:7)
+#3      _LocalLibraryMirror._invoke (dart:mirrors-patch/mirrors_impl.dart:1313)
+#4      _LocalObjectMirror.invoke (dart:mirrors-patch/mirrors_impl.dart:382)
+#5      TaskDiscovery.discoverDeclaration.<anon> (package:grinder/src/discover_tasks.dart:80:44)
+#6      _rootRun (dart:async/zone.dart:895)
+#7      _CustomZone.run (dart:async/zone.dart:796)
+#8      runZoned (dart:async/zone.dart:1251)
+#9      ZonedValue.withValue (package:grinder/src/utils.dart:115:20)
+#10     GrinderTask.execute (package:grinder/grinder.dart:169:36)
+#11     Grinder._executeTask (package:grinder/grinder.dart:373:30)
+#12     Grinder.start.<anon> (package:grinder/grinder.dart:348:28)
+#13     Future.forEach.<anon>.<anon> (dart:async/future.dart:336)
+#14     Future.Future.sync (dart:async/future.dart:168)
+#15     Future.forEach.<anon> (dart:async/future.dart:336)
+#16     Future.Future.sync (dart:async/future.dart:168)
+#17     Future.doWhile.<anon> (dart:async/future.dart:361)
+#18     _RootZone.runUnaryGuarded (dart:async/zone.dart:1093)
+#19     _RootZone.bindUnaryCallback.<anon> (dart:async/zone.dart:1122)
+#20     _RootZone.runUnary (dart:async/zone.dart:1155)
+#21     _Future._propagateToListeners.handleValueCallback (dart:async/future_impl.dart:484)
+#22     _Future._propagateToListeners (dart:async/future_impl.dart:567)
+#23     _Future._completeWithValue (dart:async/future_impl.dart:358)
+#24     _Future._asyncComplete.<anon> (dart:async/future_impl.dart:412)
+#25     _asyncRunCallbackLoop (dart:async/schedule_microtask.dart:41)
+#26     _asyncRunCallback (dart:async/schedule_microtask.dart:48)
+#27     _runPendingImmediateCallback (dart:isolate-patch/isolate_patch.dart:96)
+#28     _Timer._runTimers (dart:isolate-patch/timer_impl.dart:392)
+#29     _handleMessage (dart:isolate-patch/timer_impl.dart:411)
+#30     _RawReceivePortImpl._handleMessage (dart:isolate-patch/isolate_patch.dart:142)
+''';
+
+final _stExpected = '''
+#0      GrinderContext.fail (package:grinder/grinder.dart:131:5)
+#1      fail (package:grinder/grinder.dart:85:42)
+#2      analyze (file:///Users/devoncarew/projects/grinder.dart/tool/grind.dart:17:7)''';


### PR DESCRIPTION
Fix #113.

- ensure we exit with a non-zero code on script failures
- cleanup our display of stack traces on failures. with the move to zones, the stack can be ~30 frames deep