### PR TITLE
deprecate defaultInit()

### DIFF
--- a/bin/init.dart
+++ b/bin/init.dart
@@ -37,7 +37,9 @@ import 'package:grinder/grinder.dart';
 main(args) => grind(args);
 
 @Task()
-init() => defaultInit();
+init() {
+  log('perform init tasks...');
+}
 
 @DefaultTask()
 @Depends(init)

--- a/lib/grinder.dart
+++ b/lib/grinder.dart
@@ -57,9 +57,9 @@ void task(String name, [Function taskFunction, List<String> depends = const []])
 /// recognized options such as --help.
 ///
 /// If a task fails, throw a [GrinderException] and runs no further tasks.
-Future grind(List<String> args) => new Future(() {
+Future grind(List<String> args, {bool verifyLocation: true}) => new Future(() {
   discoverTasks(grinder, currentMirrorSystem().isolate.rootLibrary);
-  return handleArgs(args);
+  return handleArgs(args, verifyLocation: verifyLocation);
 });
 
 /**
@@ -68,8 +68,8 @@ Future grind(List<String> args) => new Future(() {
  * throw a [GrinderException].
  */
 @Deprecated('Use `grind` instead.')
-Future startGrinder(List<String> args) {
-  return handleArgs(args);
+Future startGrinder(List<String> args, {bool verifyLocation: true}) {
+  return handleArgs(args, verifyLocation: verifyLocation);
 }
 
 // Zone variables.

--- a/lib/grinder.dart
+++ b/lib/grinder.dart
@@ -56,10 +56,13 @@ void task(String name, [Function taskFunction, List<String> depends = const []])
 /// the command-line [args] either by running tasks or responding to
 /// recognized options such as --help.
 ///
+/// If [verifyProjectRoot] is true, grinder will verify that the script is being
+/// run from a project root.
+///
 /// If a task fails, throw a [GrinderException] and runs no further tasks.
-Future grind(List<String> args, {bool verifyLocation: true}) => new Future(() {
+Future grind(List<String> args, {bool verifyProjectRoot: true}) => new Future(() {
   discoverTasks(grinder, currentMirrorSystem().isolate.rootLibrary);
-  return handleArgs(args, verifyLocation: verifyLocation);
+  return handleArgs(args, verifyProjectRoot: verifyProjectRoot);
 });
 
 /**
@@ -68,8 +71,8 @@ Future grind(List<String> args, {bool verifyLocation: true}) => new Future(() {
  * throw a [GrinderException].
  */
 @Deprecated('Use `grind` instead.')
-Future startGrinder(List<String> args, {bool verifyLocation: true}) {
-  return handleArgs(args, verifyLocation: verifyLocation);
+Future startGrinder(List<String> args, {bool verifyProjectRoot: true}) {
+  return handleArgs(args, verifyProjectRoot: verifyProjectRoot);
 }
 
 // Zone variables.

--- a/lib/grinder_files.dart
+++ b/lib/grinder_files.dart
@@ -355,9 +355,7 @@ Directory getDir(String path) {
 }
 
 void copy(FileSystemEntity entity, Directory destDir, [GrinderContext context]) {
-  if (context != null) {
-    context.log('copying ${entity.path} to ${destDir.path}');
-  }
+  log('copying ${entity.path} to ${destDir.path}');
   return _copyImpl(entity, destDir, context);
 }
 
@@ -386,7 +384,7 @@ void _copyImpl(FileSystemEntity entity, Directory destDir, [GrinderContext conte
 }
 
 /// Delete the given file entity reference.
-void delete(FileSystemEntity entity) =>_deleteImpl(entity);
+void delete(FileSystemEntity entity) => _deleteImpl(entity);
 
 void _deleteImpl(FileSystemEntity entity) {
   if (entity.existsSync()) {

--- a/lib/grinder_tools.dart
+++ b/lib/grinder_tools.dart
@@ -77,7 +77,7 @@ void runProcess(String executable,
      bool quiet: false,
      String workingDirectory,
      Map<String, String> environment}) {
-  context.log("${executable} ${arguments.join(' ')}");
+  log("${executable} ${arguments.join(' ')}");
 
   ProcessResult result = Process.runSync(
       executable, arguments, workingDirectory: workingDirectory,
@@ -85,12 +85,12 @@ void runProcess(String executable,
 
   if (!quiet) {
     if (result.stdout != null && !result.stdout.isEmpty) {
-      context.log(result.stdout.trim());
+      log(result.stdout.trim());
     }
   }
 
   if (result.stderr != null && !result.stderr.isEmpty) {
-    context.log(result.stderr);
+    log(result.stderr);
   }
 
   if (result.exitCode != 0) {
@@ -106,7 +106,7 @@ Future runProcessAsync(String executable,
     {List<String> arguments : const [],
      bool quiet: false,
      String workingDirectory}) {
-  context.log("${executable} ${arguments.join(' ')}");
+  log("${executable} ${arguments.join(' ')}");
 
   return Process.start(executable, arguments, workingDirectory: workingDirectory)
       .then((Process process) {
@@ -114,14 +114,14 @@ Future runProcessAsync(String executable,
     process.stdout.listen((List<int> data) {
       if (!quiet) {
         String str = new String.fromCharCodes(data).trimRight();
-        if (str.isNotEmpty) context.log(str);
+        if (str.isNotEmpty) log(str);
       }
     });
 
     // Handle stderr.
     process.stderr.listen((List<int> data) {
       String str = new String.fromCharCodes(data).trimRight();
-      if (str.isNotEmpty) context.log('stderr: $str');
+      if (str.isNotEmpty) log('stderr: $str');
     });
 
     return process.exitCode.then((int code) {
@@ -135,25 +135,14 @@ Future runProcessAsync(String executable,
   });
 }
 
-/**
- * A default implementation of an `init` task. This task verifies that the grind
- * script is executed from the project root.
- */
-void defaultInit([GrinderContext context]) {
-  // Verify that we're running in the project root.
-  if (!getFile('pubspec.yaml').existsSync()) {
-    fail('This script must be run from the project root.');
-  }
-}
+/// A default implementation of an `init` task. This task verifies that the
+/// grind script is executed from the project root.
+@Deprecated('the functionality of this method has been rolled into grinder startup')
+void defaultInit([GrinderContext context]) { }
 
-/**
- * A default implementation of a `clean` task. This task deletes all generated
- * artifacts in the `build/`.
- */
-void defaultClean([GrinderContext context]) {
-  // Delete the `build/` dir.
-  delete(BUILD_DIR);
-}
+/// A default implementation of a `clean` task. This task deletes all generated
+/// artifacts in the `build/`.
+void defaultClean([GrinderContext context]) => delete(BUILD_DIR);
 
 /**
  * Utility tasks for executing pub commands.
@@ -444,7 +433,7 @@ class Tests {
    */
   static void runCliTests({String directory: 'test', String testFile: 'all.dart'}) {
     String file = '${directory}/${testFile}';
-    context.log('running tests: ${file}...');
+    log('running tests: ${file}...');
     runDartScript(file);
   }
 
@@ -482,10 +471,10 @@ class Tests {
     return MicroServer.start(port: 0, path: directory).then((s) {
       server = s;
 
-      context.log("microserver serving '${server.path}' on ${server.urlBase}");
+      log("microserver serving '${server.path}' on ${server.urlBase}");
 
       // Start the browser.
-      context.log('opening ${browser.browserPath}');
+      log('opening ${browser.browserPath}');
 
       List<String> args = ['--remote-debugging-port=${wip}'];
       if (Platform.environment['CHROME_ARGS'] != null) {
@@ -503,7 +492,7 @@ class Tests {
     }).then((t) {
       tab = t;
 
-      context.log('connected to ${tab}');
+      log('connected to ${tab}');
 
       // Connect via WIP.
       return WipConnection.connect(tab.webSocketDebuggerUrl);
@@ -533,7 +522,7 @@ class Tests {
       sub = connection.console.onMessage.listen(
           (ConsoleMessageEvent event) {
         timer.reset();
-        context.log(event.text);
+        log(event.text);
 
         // 'tests finished - passed' or 'tests finished - failed'.
         if (event.text.contains('tests finished -')) {
@@ -613,7 +602,7 @@ class Chrome {
     args.add(url);
 
     // TODO: This process often won't terminate, so that's a problem.
-    context.log("starting chrome...");
+    log("starting chrome...");
     runProcess(browserPath, arguments: args, environment: envVars);
   }
 
@@ -634,12 +623,12 @@ class Chrome {
         .then((Process process) {
       // Handle stdout.
       process.stdout.listen((List<int> data) {
-        context.log(new String.fromCharCodes(data).trim());
+        log(new String.fromCharCodes(data).trim());
       });
 
       // Handle stderr.
       process.stderr.listen((List<int> data) {
-        context.log('stderr: ${new String.fromCharCodes(data).trim()}');
+        log('stderr: ${new String.fromCharCodes(data).trim()}');
       });
 
       return process;

--- a/lib/src/cli.dart
+++ b/lib/src/cli.dart
@@ -19,7 +19,7 @@ const String APP_VERSION = '0.6.6+3';
 List<String> grinderArgs() => _args;
 List<String> _args;
 
-Future handleArgs(List<String> args) {
+Future handleArgs(List<String> args, {bool verifyLocation: true}) {
   _args = args == null ? [] : args;
 
   ArgParser parser = createArgsParser();
@@ -44,6 +44,13 @@ Future handleArgs(List<String> args) {
   } else if (results['deps']) {
     printDeps(grinder);
   } else {
+    if (verifyLocation) {
+      // Verify that we're running from the project root.
+      if (!getFile('pubspec.yaml').existsSync()) {
+        fail('This script must be run from the project root.');
+      }
+    }
+
     Future result = grinder.start(results.rest);
 
     return result.catchError((e, st) {

--- a/lib/src/cli.dart
+++ b/lib/src/cli.dart
@@ -19,7 +19,7 @@ const String APP_VERSION = '0.6.6+3';
 List<String> grinderArgs() => _args;
 List<String> _args;
 
-Future handleArgs(List<String> args, {bool verifyLocation: true}) {
+Future handleArgs(List<String> args, {bool verifyProjectRoot: true}) {
   _args = args == null ? [] : args;
 
   ArgParser parser = createArgsParser();
@@ -44,7 +44,7 @@ Future handleArgs(List<String> args, {bool verifyLocation: true}) {
   } else if (results['deps']) {
     printDeps(grinder);
   } else {
-    if (verifyLocation) {
+    if (verifyProjectRoot) {
       // Verify that we're running from the project root.
       if (!getFile('pubspec.yaml').existsSync()) {
         fail('This script must be run from the project root.');

--- a/tool/grind.dart
+++ b/tool/grind.dart
@@ -9,23 +9,17 @@ import 'package:grinder/grinder.dart';
 main(args) => grind(args);
 
 @Task()
-void init() => defaultInit();
-
-@Task()
-@Depends(init)
 void analyze() {
   PubApplication tuneupApp = new PubApplication('tuneup');
   tuneupApp.run(['check']);
 }
 
 @Task()
-@Depends(init)
 void test() {
   Tests.runCliTests();
 }
 
 @Task('Check that the generated init grind script analyzes well')
-@Depends(init)
 checkInit() {
   Path tempProject = Path.createSystemTemp();
 
@@ -43,7 +37,6 @@ checkInit() {
 }
 
 @Task('Gather and send coverage data.')
-@Depends(init)
 void coverage() {
   final String coverageToken = Platform.environment['REPO_TOKEN'];
 
@@ -67,13 +60,11 @@ void buildbot() => null;
 // These tasks require a frame buffer to run.
 
 @Task()
-@Depends(init)
 Future testsWeb() {
   return Tests.runWebTests(directory: 'web', htmlFile: 'web.html');
 }
 
 @Task()
-@Depends(init)
 Future testsBuildWeb() {
   return Pub.buildAsync(directories: ['web']).then((_) {
     return Tests.runWebTests(directory: 'build/web', htmlFile: 'web.html');


### PR DESCRIPTION
fix #137 

Move the functionality of `defaultInit()` into the grinder startup sequence (`handleArgs()`). Deprecate defaultInit. I kept a sample `init` task in the bootstrap grind.dart script we generate in order to demonstrate how to specify task dependencies.

@seaneagan 