### PR TITLE
remove a call to logging

### DIFF
--- a/lib/grinder_tools.dart
+++ b/lib/grinder_tools.dart
@@ -227,7 +227,8 @@ class PubGlobal {
     //discoveryapis_generator 0.6.1
     //...
 
-    var stdout = run_lib.run(_sdkBin('pub'), arguments: ['global', 'list'], quiet: true);
+    var stdout = run_lib.run(
+        _sdkBin('pub'), arguments: ['global', 'list'], quiet: true);
 
     var lines = stdout.trim().split('\n');
     return lines.map((line) {

--- a/lib/src/run.dart
+++ b/lib/src/run.dart
@@ -21,7 +21,7 @@ String run(String executable,
      bool quiet: false,
      String workingDirectory,
      Map<String, String> environment}) {
-  log("${executable} ${arguments.join(' ')}");
+  if (!quiet) log("${executable} ${arguments.join(' ')}");
 
   ProcessResult result = Process.runSync(
       executable, arguments, workingDirectory: workingDirectory,
@@ -99,7 +99,8 @@ Future<String> runAsync(String executable,
       var stdoutString = SYSTEM_ENCODING.decode(stdout);
 
       if (code != 0) {
-        throw new ProcessException._(executable, code, stdoutString, SYSTEM_ENCODING.decode(stderr));
+        throw new ProcessException._(executable, code, stdoutString,
+            SYSTEM_ENCODING.decode(stderr));
       }
 
       return stdoutString;


### PR DESCRIPTION
Remove an extraneous logging call - `pub global list` - found in https://github.com/google/grinder.dart/issues/172.