### PR TITLE
fixes to running w/o a task specified; cleanup help text

### DIFF
--- a/changelog.md
+++ b/changelog.md
@@ -1,5 +1,8 @@
 # grinder.dart changes
 
+## 0.7.1
+-
+
 ## 0.7.0
 - Big changes! Task definititions are now primarily annotation based; see the
   [readme](https://github.com/google/grinder.dart) for more information and an example

--- a/lib/src/cli.dart
+++ b/lib/src/cli.dart
@@ -103,10 +103,9 @@ void printUsageAndDeps(ArgParser parser, Grinder grinder) {
       bool isDefault = grinder.defaultTask == task;
       Iterable<GrinderTask> deps = grinder.getImmediateDependencies(task);
 
-      String str = '${task}\n';
-      if (isDefault) str += '  @DefaultTask\n';
+      String str = '${task}${isDefault ? ' (default)' : ''}\n';
       if (task.description != null) str += '  ${task.description}\n';
-      if (deps.isNotEmpty) str += '  @Depends: ${deps.map((t) => t.toString()).join(' ')}\n';
+      if (deps.isNotEmpty) str += '  depends on: ${deps.map((t) => t.toString()).join(' ')}\n';
       return str;
     }).join('\n'));
   }

--- a/readme.md
+++ b/readme.md
@@ -67,7 +67,7 @@ or to run a default task (see `@DefaultTask` above):
 
     grind
 
-or to display a list of available tasks:
+or to display a list of available tasks and their dependencies:
 
     grind -h
 

--- a/test/all.dart
+++ b/test/all.dart
@@ -4,7 +4,8 @@
 library all_test;
 
 import 'src/cli_test.dart' as src_cli_test;
-import 'task_discovery/discover_tasks_test.dart' as discover_tasks_test;
+import 'src/discover_tasks_test.dart' as src_discover_tasks_test;
+import 'src/utils_test.dart' as src_utils_test;
 import 'cli_test.dart' as cli_test;
 import 'grinder_test.dart' as grinder_test;
 import 'grinder_files_test.dart' as grinder_files_test;
@@ -12,7 +13,8 @@ import 'grinder_tools_test.dart' as grinder_tools_test;
 
 main() {
   src_cli_test.main();
-  discover_tasks_test.main();
+  src_discover_tasks_test.main();
+  src_utils_test.main();
   cli_test.main();
   grinder_test.main();
   grinder_files_test.main();

--- a/test/cli_test.dart
+++ b/test/cli_test.dart
@@ -30,12 +30,8 @@ main() {
       });
     });
 
-    test('printUsage', () {
-      printUsage(createArgsParser(), grinder);
-    });
-
-    test('printDeps', () {
-      printDeps(grinder);
+    test('printUsageAndDeps', () {
+      printUsageAndDeps(createArgsParser(), grinder);
     });
   });
 }

--- a/test/grinder_test.dart
+++ b/test/grinder_test.dart
@@ -10,7 +10,6 @@ import 'package:unittest/unittest.dart';
 
 main() {
   group('grinder', () {
-
     test('tasks must have a task function or dependencies', () {
       expect(() {
         new GrinderTask('foo', taskFunction: null, depends: []);

--- a/test/grinder_tools_test.dart
+++ b/test/grinder_tools_test.dart
@@ -12,6 +12,12 @@ import 'utils.dart';
 
 main() {
   group('grinder.tools', () {
+    MockGrinderContext mockContext;
+
+    setUp(() {
+      mockContext = new MockGrinderContext();
+    });
+
     test('sdkDir', () {
       if (Platform.environment['DART_SDK'] != null) {
         expect(sdkDir, isNotNull);
@@ -29,36 +35,48 @@ main() {
     });
 
     test('dart2js version', () {
-      MockGrinderContext context = new MockGrinderContext();
-      Dart2js.version();
-      expect(context.isFailed, false);
+      return mockContext.runZoned(() {
+        expect(Dart2js.version(), isNotNull);
+      }).then((_) {
+        expect(mockContext.logBuffer, isNotEmpty);
+        expect(mockContext.isFailed, false);
+      });
     });
 
     test('analyzer version', () {
-      MockGrinderContext context = new MockGrinderContext();
-      Analyzer.version();
-      expect(context.isFailed, false);
+      return mockContext.runZoned(() {
+        expect(Analyzer.version(), isNotNull);
+      }).then((_) {
+        expect(mockContext.logBuffer, isNotEmpty);
+        expect(mockContext.isFailed, false);
+      });
     });
-  });
 
-  group('grinder.tools.pub', () {
-    test('version', () {
-      MockGrinderContext context = new MockGrinderContext();
-      Pub.version();
-      expect(context.isFailed, false);
+    test('Pub.version', () {
+      return mockContext.runZoned(() {
+        expect(Pub.version(), isNotNull);
+      }).then((_) {
+        expect(mockContext.logBuffer, isNotEmpty);
+        expect(mockContext.isFailed, false);
+      });
     });
 
     // See #166.
-//    test('global list', () {
-//      MockGrinderContext context = new MockGrinderContext();
-//      expect(Pub.global._list(), isNotNull);
-//      expect(context.isFailed, false);
+//    test('Pub.list', () {
+//      return mockContext.runZoned(() {
+//        expect(Pub.global._list(), isNotNull);
+//      }).then((_) {
+//        expect(mockContext.logBuffer, isNotEmpty);
+//        expect(mockContext.isFailed, false);
+//      });
 //    });
 
-    test('isActivated', () {
-      MockGrinderContext context = new MockGrinderContext();
-      expect(Pub.global.isActivated('foo'), false);
-      expect(context.isFailed, false);
+    test('Pub.isActivated', () {
+      return mockContext.runZoned(() {
+        expect(Pub.global.isActivated('foo'), false);
+      }).then((_) {
+        expect(mockContext.isFailed, false);
+      });
     });
 
     test('PubApp.global', () {

--- a/test/src/discover_tasks_test.dart
+++ b/test/src/discover_tasks_test.dart
@@ -9,9 +9,9 @@ import 'package:grinder/grinder.dart';
 import 'package:grinder/src/discover_tasks.dart';
 import 'package:unittest/unittest.dart';
 
-import 'good_tasks.dart' as good;
-import 'bad_tasks.dart' as bad;
-import 'external_tasks.dart' as external;
+import '../task_discovery/good_tasks.dart' as good;
+import '../task_discovery/bad_tasks.dart' as bad;
+import '../task_discovery/external_tasks.dart' as external;
 
 main() {
   // Libs which contains annotated tasks (imported above).

--- a/test/src/utils_test.dart
+++ b/test/src/utils_test.dart
@@ -1,0 +1,28 @@
+// Copyright 2015 Google. All rights reserved. Use of this source code is
+// governed by a BSD-style license that can be found in the LICENSE file.
+
+library grinder.src.utils_test;
+
+import 'package:grinder/src/utils.dart';
+import 'package:unittest/unittest.dart';
+
+main() {
+  group('src.utils', () {
+    test('httpGet', () {
+      return httpGet('http://httpbin.org/get').then((result) {
+        expect(result, isNotEmpty);
+      });
+    });
+
+    test('ResettableTimer', () {
+      ResettableTimer timer = new ResettableTimer(new Duration(seconds: 1), () {
+        fail("timer shouldn't have fired'");
+      });
+      expect(timer.isActive, true);
+      timer.reset();
+      expect(timer.isActive, true);
+      timer.cancel();
+      expect(timer.isActive, false);
+    });
+  });
+}

--- a/test/utils.dart
+++ b/test/utils.dart
@@ -3,7 +3,10 @@
 
 library grinder_test_utils;
 
+import 'dart:async';
+
 import 'package:grinder/grinder.dart';
+import 'package:grinder/src/singleton.dart';
 
 class MockGrinderContext implements GrinderContext {
   Grinder grinder;
@@ -14,6 +17,11 @@ class MockGrinderContext implements GrinderContext {
 
   bool get isFailed => failBuffer.isNotEmpty;
 
-  void log(String message) => logBuffer.write(message);
-  void fail(String message) => failBuffer.write(message);
+  void log(String message) => logBuffer.write('${message}\n');
+  void fail(String message) => failBuffer.write('${message}\n');
+
+  Future runZoned(Function f) {
+    var result = zonedContext.withValue(this, f);
+    return result is Future ? result : new Future.value();
+  }
 }

--- a/tool/grind.dart
+++ b/tool/grind.dart
@@ -18,7 +18,7 @@ void test() {
   Tests.runCliTests();
 }
 
-@Task('Check that the generated init grind script analyzes well')
+@Task('Check that the generated `init` grind script analyzes well.')
 checkInit() {
   FilePath temp = FilePath.createSystemTemp();
 


### PR DESCRIPTION
Fix #140, fix #119.

- fix an issue when running grinder w/ an invalid task name. It would print a long microqueue stack chain. It now prints `task 'foobar' doesn't exist` and exits with code 1.
- hide the `-d` option; aliased it to `-h`
- improved the help / deps output (see below)
- changed some tests to use a mock context when running
- added tests for some classes in the `src/utils` library

```
usage: dart tool/grind.dart <options> target1 target2 ...

valid options:
    --dart-sdk    set the location of the Dart SDK
    --version     print the version of grinder
-h, --help        show targets but don't build

targets:

[coverage]
  Gather and send coverage data.

[test]

[tests-build-web]

[analyze]

[tests-web]

[check-init]
  Check that the generated `init` grind script analyzes well.

[buildbot]
  @DefaultTask
  @Depends: [analyze] [test] [check-init] [coverage]
```