### PR TITLE
coerce platform independent paths

### DIFF
--- a/lib/grinder_files.dart
+++ b/lib/grinder_files.dart
@@ -117,6 +117,8 @@ class FilePath {
   /// Create a new [FilePath]. The [entityOrString] parameter can be a
   /// [FileSystemEntity] or a [String]. If a [String], this method converts the
   /// given path from a platform independent one to a platform dependent path.
+  /// This conversion will work for relative paths but wouldn't make sense to
+  /// use for absolute ones.
   FilePath(entityOrString) : _path = _coerce(entityOrString);
 
   String get name {

--- a/lib/grinder_files.dart
+++ b/lib/grinder_files.dart
@@ -115,7 +115,8 @@ class FilePath {
   final String _path;
 
   /// Create a new [FilePath]. The [entityOrString] parameter can be a
-  /// [FileSystemEntity] or a [String].
+  /// [FileSystemEntity] or a [String]. If a [String], this method converts the
+  /// given path from a platform independent one to a platform dependent path.
   FilePath(entityOrString) : _path = _coerce(entityOrString);
 
   String get name {
@@ -267,6 +268,8 @@ class FilePath {
 
   static String _coerce(arg) {
     if (arg is String) {
+      if (_sep != '/') arg = arg.replaceAll('/', _sep);
+
       if (arg.length > 1 && arg.endsWith((_sep))) {
         return arg.substring(0, arg.length - 1);
       } else {

--- a/test/grinder_files_test.dart
+++ b/test/grinder_files_test.dart
@@ -8,6 +8,8 @@ import 'dart:io';
 import 'package:grinder/grinder.dart';
 import 'package:unittest/unittest.dart';
 
+final String _sep = Platform.pathSeparator;
+
 main() {
   group('grinder.files FileSet', () {
     Directory temp;
@@ -15,17 +17,15 @@ main() {
     File fileB;
 
     setUp(() {
-      final String sep = Platform.pathSeparator;
-
       temp = Directory.systemTemp.createTempSync();
 
-      fileB = new File('${temp.path}${sep}b.txt');
+      fileB = new File('${temp.path}${_sep}b.txt');
       fileB.writeAsStringSync('b');
 
-      fileA = new File('${temp.path}${sep}a.txt');
+      fileA = new File('${temp.path}${_sep}a.txt');
       fileA.writeAsStringSync('a');
 
-      File subFile = new File('${temp.path}${sep}foo${sep}sub.txt');
+      File subFile = new File('${temp.path}${_sep}foo${_sep}sub.txt');
       subFile.createSync(recursive: true);
       subFile.writeAsStringSync('sub');
     });
@@ -81,7 +81,6 @@ main() {
 
   group('grinder.files', () {
     Directory temp;
-    final String sep = Platform.pathSeparator;
 
     setUp(() {
       temp = Directory.systemTemp.createTempSync();
@@ -93,39 +92,39 @@ main() {
 
     test('fileName', () {
       final String tempFileName = "temp.txt";
-      File tempFile = new File('${temp.path}${sep}tempdir${sep}${tempFileName}');
+      File tempFile = new File('${temp.path}${_sep}tempdir${_sep}${tempFileName}');
       expect(fileName(tempFile), tempFileName);
     });
 
     test('fileExt', () {
       final String extension = 'txt';
       final String fileName = 'temp' + '.' + extension;
-      File tempFile = new File('${temp.path}${sep}tempdir${sep}${fileName}');
+      File tempFile = new File('${temp.path}${_sep}tempdir${_sep}${fileName}');
       expect(fileExt(tempFile), extension);
 
       final fileNameEmptyExt = 'temp.';
-      tempFile = new File('${temp.path}${sep}tempdir${sep}${fileNameEmptyExt}');
+      tempFile = new File('${temp.path}${_sep}tempdir${_sep}${fileNameEmptyExt}');
       expect(fileExt(tempFile), '');
     });
 
     test('fileExt null', () {
       String fileNameNoExt = 'temp';
       File tempFile =
-        new File('${temp.path}${sep}tempdir${sep}${fileNameNoExt}');
+        new File('${temp.path}${_sep}tempdir${_sep}${fileNameNoExt}');
       expect(fileExt(tempFile), null);
     });
 
     test('joinFile', () {
       File tempFile = joinFile(Directory.current, ['dir','test']);
       File expectedFile =
-        new File('${Directory.current.path}${sep}dir${sep}test');
+        new File('${Directory.current.path}${_sep}dir${_sep}test');
       expect(tempFile.path, expectedFile.path);
     });
 
     test('joinDir', () {
       Directory tempDirectory = joinDir(Directory.current, ['dir','test']);
       Directory expectedDir =
-        new Directory('${Directory.current.path}${sep}dir${sep}test');
+        new Directory('${Directory.current.path}${_sep}dir${_sep}test');
       expect(tempDirectory.path, expectedDir.path);
     });
 
@@ -192,7 +191,15 @@ main() {
       expect(file.isDirectory, false);
       expect(file.name, 'temp.txt');
 
-      expect(new FilePath(dir.path + Platform.pathSeparator).path, dir.path);
+      expect(new FilePath(dir.path + _sep).path, dir.path);
+    });
+
+    test('FilePath(str) platform independent', () {
+      FilePath file = temp.join('temp.txt');
+      file.asFile.writeAsStringSync('foo\n', flush: true);
+      expect(file.exists, true);
+      FilePath file2 = new FilePath(file.path.replaceAll(_sep, '/'));
+      expect(file2.exists, true);
     });
 
     test('current', () {


### PR DESCRIPTION
In the ctor of `FilePath`, coerce platform independent paths to platform dependent ones.