### PR TITLE
add dartfmt support

### DIFF
--- a/lib/grinder_sdk.dart
+++ b/lib/grinder_sdk.dart
@@ -33,13 +33,9 @@ Directory getSdkDir([List<String> cliArgs]) => cli_util.getSdkDir(cliArgs);
 
 File get dartVM => joinFile(sdkDir, ['bin', _sdkBin('dart')]);
 
-/// Utility tasks for for getting information about the Dart SDK and invoking
-/// dart applications.
+/// Utility tasks for for getting information about the Dart VM and for running
+/// Dart applications.
 class Dart {
-  /// Return the path to the current Dart SDK. This will return `null` if we are
-  /// unable to locate the Dart SDK.
-  static Directory get location => sdkDir;
-
   /// Run a dart [script] using [run_lib.run].
   ///
   /// Returns the stdout.
@@ -77,6 +73,12 @@ class Dart {
     return Platform.version.substring(0, Platform.version.indexOf(' '));
   }
 }
+
+//class DartSdk {
+//  /// Return the path to the current Dart SDK. This will return `null` if we are
+//  /// unable to locate the Dart SDK.
+//  static Directory get location => sdkDir;
+//}
 
 /**
  * Utility tasks for executing pub commands.

--- a/lib/grinder_sdk.dart
+++ b/lib/grinder_sdk.dart
@@ -269,7 +269,8 @@ class Analyzer {
       _sdkBin('dartanalyzer'), quiet: quiet, arguments: ['--version'])).version;
 }
 
-/// Utility class for invoking `dartfmt` from the SDK.
+/// Utility class for invoking `dartfmt` from the SDK. This wrapper requires
+/// the `dartfmt` from SDK 1.9 and greater.
 class DartFmt {
   /// Run the `dartfmt` command with the `--overwrite` option. Format any files
   /// in place.

--- a/lib/grinder_sdk.dart
+++ b/lib/grinder_sdk.dart
@@ -33,6 +33,51 @@ Directory getSdkDir([List<String> cliArgs]) => cli_util.getSdkDir(cliArgs);
 
 File get dartVM => joinFile(sdkDir, ['bin', _sdkBin('dart')]);
 
+/// Utility tasks for for getting information about the Dart SDK and invoking
+/// dart applications.
+class Dart {
+  /// Return the path to the current Dart SDK. This will return `null` if we are
+  /// unable to locate the Dart SDK.
+  static Directory get location => sdkDir;
+
+  /// Run a dart [script] using [run_lib.run].
+  ///
+  /// Returns the stdout.
+  static String run(String script,
+      {List<String> arguments : const [], bool quiet: false,
+       String packageRoot, String workingDirectory, int vmNewGenHeapMB,
+       int vmOldGenHeapMB}) {
+    List<String> args = [];
+
+    if (packageRoot != null) {
+      args.add('--package-root=${packageRoot}');
+    }
+
+    if (vmNewGenHeapMB != null) {
+      args.add('--new_gen_heap_size=${vmNewGenHeapMB}');
+    }
+
+    if (vmOldGenHeapMB != null) {
+      args.add('--old_gen_heap_size=${vmOldGenHeapMB}');
+    }
+
+    args.add(script);
+    args.addAll(arguments);
+
+    return run_lib.run(_sdkBin('dart'), arguments: args, quiet: quiet,
+        workingDirectory: workingDirectory);
+  }
+
+  static String version({bool quiet: false}) {
+    // TODO: We may want to run `dart --version` in order to know the version
+    // of the SDK that grinder has located.
+    //run_lib.run(_sdkBin('dart'), arguments: ['--version'], quiet: quiet);
+    // The stdout does not have a stable documented format, so use the provided
+    // metadata instead.
+    return Platform.version.substring(0, Platform.version.indexOf(' '));
+  }
+}
+
 /**
  * Utility tasks for executing pub commands.
  */
@@ -146,6 +191,103 @@ class Pub {
   }
 }
 
+/**
+ * Utility tasks for invoking dart2js.
+ */
+class Dart2js {
+  /**
+   * Invoke a dart2js compile with the given [sourceFile] as input.
+   */
+  static void compile(File sourceFile,
+      {Directory outDir, bool minify: false, bool csp: false}) {
+    if (outDir == null) outDir = sourceFile.parent;
+    File outFile = joinFile(outDir, ["${fileName(sourceFile)}.js"]);
+
+    if (!outDir.existsSync()) outDir.createSync(recursive: true);
+
+    List args = [];
+    if (minify) args.add('--minify');
+    if (csp) args.add('--csp');
+    args.add('-o${outFile.path}');
+    args.add(sourceFile.path);
+
+    run_lib.run(_sdkBin('dart2js'), arguments: args);
+  }
+
+  /**
+   * Invoke a dart2js compile with the given [sourceFile] as input.
+   */
+  static Future compileAsync(File sourceFile,
+      {Directory outDir, bool minify: false, bool csp: false}) {
+    if (outDir == null) outDir = sourceFile.parent;
+    File outFile = joinFile(outDir, ["${fileName(sourceFile)}.js"]);
+
+    if (!outDir.existsSync()) outDir.createSync(recursive: true);
+
+    List args = [];
+    if (minify) args.add('--minify');
+    if (csp) args.add('--csp');
+    args.add('-o${outFile.path}');
+    args.add(sourceFile.path);
+
+    return run_lib.runAsync(_sdkBin('dart2js'), arguments: args)
+        .then((_) => null);
+  }
+
+  static String version({bool quiet: false}) =>
+      _AppVersion.parse(_run('--version', quiet: quiet)).version;
+
+  static String _run(String command, {bool quiet: false}) =>
+      run_lib.run(_sdkBin('dart2js'), quiet: quiet, arguments: [command]);
+}
+
+/**
+ * Utility tasks for invoking the analyzer.
+ */
+class Analyzer {
+  /// Analyze a single [File] or path ([String]).
+  static void analyze(fileOrPath,
+      {Directory packageRoot, bool fatalWarnings: false}) {
+    analyzeFiles([fileOrPath], packageRoot: packageRoot,
+        fatalWarnings: fatalWarnings);
+  }
+
+  /// Analyze one or more [File]s or paths ([String]).
+  static void analyzeFiles(List files,
+      {Directory packageRoot, bool fatalWarnings: false}) {
+    List args = [];
+    if (packageRoot != null) args.add('--package-root=${packageRoot.path}');
+    if (fatalWarnings) args.add('--fatal-warnings');
+    args.addAll(files.map((f) => f is File ? f.path : f));
+
+    run_lib.run(_sdkBin('dartanalyzer'), arguments: args);
+  }
+
+  static String version({bool quiet: false}) => _AppVersion.parse(run_lib.run(
+      _sdkBin('dartanalyzer'), quiet: quiet, arguments: ['--version'])).version;
+}
+
+/// Utility class for invoking `dartfmt` from the SDK.
+class DartFmt {
+  /// Run the `dartfmt` command with the `--overwrite` option. Format any files
+  /// in place.
+  static void format(fileOrPath) {
+    if (fileOrPath is File) fileOrPath = fileOrPath.path;
+    _run('--overwrite', fileOrPath);
+  }
+
+  /// Run the `dartfmt` command with the `--dry-run` option. Return `true` if
+  /// any files would be changed by running the formatter.
+  static bool dryRun(fileOrPath) {
+    if (fileOrPath is File) fileOrPath = fileOrPath.path;
+    String results = _run('--dry-run', fileOrPath);
+    return results.trim().isNotEmpty;
+  }
+
+  static String _run(String option, String target, {bool quiet: false}) =>
+      run_lib.run(_sdkBin('dartfmt'), quiet: quiet, arguments: [option, target]);
+}
+
 /// Access the `pub global` commands.
 class PubGlobal {
   Set<String> _activatedPackages;
@@ -235,82 +377,6 @@ abstract class PubApp {
   String run(List<String> arguments, {String script, String workingDirectory});
 
   String toString() => packageName;
-}
-
-/**
- * Utility tasks for invoking dart2js.
- */
-class Dart2js {
-  /**
-   * Invoke a dart2js compile with the given [sourceFile] as input.
-   */
-  static void compile(File sourceFile,
-      {Directory outDir, bool minify: false, bool csp: false}) {
-    if (outDir == null) outDir = sourceFile.parent;
-    File outFile = joinFile(outDir, ["${fileName(sourceFile)}.js"]);
-
-    if (!outDir.existsSync()) outDir.createSync(recursive: true);
-
-    List args = [];
-    if (minify) args.add('--minify');
-    if (csp) args.add('--csp');
-    args.add('-o${outFile.path}');
-    args.add(sourceFile.path);
-
-    run_lib.run(_sdkBin('dart2js'), arguments: args);
-  }
-
-  /**
-   * Invoke a dart2js compile with the given [sourceFile] as input.
-   */
-  static Future compileAsync(File sourceFile,
-      {Directory outDir, bool minify: false, bool csp: false}) {
-    if (outDir == null) outDir = sourceFile.parent;
-    File outFile = joinFile(outDir, ["${fileName(sourceFile)}.js"]);
-
-    if (!outDir.existsSync()) outDir.createSync(recursive: true);
-
-    List args = [];
-    if (minify) args.add('--minify');
-    if (csp) args.add('--csp');
-    args.add('-o${outFile.path}');
-    args.add(sourceFile.path);
-
-    return run_lib.runAsync(_sdkBin('dart2js'), arguments: args)
-        .then((_) => null);
-  }
-
-  static String version({bool quiet: false}) =>
-      _AppVersion.parse(_run('--version', quiet: quiet)).version;
-
-  static String _run(String command, {bool quiet: false}) =>
-      run_lib.run(_sdkBin('dart2js'), quiet: quiet, arguments: [command]);
-}
-
-/**
- * Utility tasks for invoking the analyzer.
- */
-class Analyzer {
-  /// Analyze a single [File] or path ([String]).
-  static void analyze(fileOrPath,
-      {Directory packageRoot, bool fatalWarnings: false}) {
-    analyzeFiles([fileOrPath], packageRoot: packageRoot,
-        fatalWarnings: fatalWarnings);
-  }
-
-  /// Analyze one or more [File]s or paths ([String]).
-  static void analyzeFiles(List files,
-      {Directory packageRoot, bool fatalWarnings: false}) {
-    List args = [];
-    if (packageRoot != null) args.add('--package-root=${packageRoot.path}');
-    if (fatalWarnings) args.add('--fatal-warnings');
-    args.addAll(files.map((f) => f is File ? f.path : f));
-
-    run_lib.run(_sdkBin('dartanalyzer'), arguments: args);
-  }
-
-  static String version({bool quiet: false}) => _AppVersion.parse(run_lib.run(
-      _sdkBin('dartanalyzer'), quiet: quiet, arguments: ['--version'])).version;
 }
 
 String _sdkBin(String name) {

--- a/lib/grinder_tools.dart
+++ b/lib/grinder_tools.dart
@@ -50,47 +50,6 @@ void defaultInit([GrinderContext context]) { }
 /// artifacts in the `build/`.
 void defaultClean([GrinderContext context]) => delete(BUILD_DIR);
 
-/// Utility tasks for invoking dart.
-class Dart {
-
-  /// Run a dart [script] using [run_lib.run].
-  ///
-  /// Returns the stdout.
-  static String run(String script,
-      {List<String> arguments : const [], bool quiet: false,
-       String packageRoot, String workingDirectory, int vmNewGenHeapMB,
-       int vmOldGenHeapMB}) {
-    List<String> args = [];
-
-    if (packageRoot != null) {
-      args.add('--package-root=${packageRoot}');
-    }
-
-    if (vmNewGenHeapMB != null) {
-      args.add('--new_gen_heap_size=${vmNewGenHeapMB}');
-    }
-
-    if (vmOldGenHeapMB != null) {
-      args.add('--old_gen_heap_size=${vmOldGenHeapMB}');
-    }
-
-    args.add(script);
-    args.addAll(arguments);
-
-    return run_lib.run(_sdkBin('dart'), arguments: args, quiet: quiet,
-        workingDirectory: workingDirectory);
-  }
-
-  static String version({bool quiet: false}) {
-    // TODO: We may want to run `dart --version` in order to know the version
-    // of the SDK that grinder has located.
-    //run_lib.run(_sdkBin('dart'), arguments: ['--version'], quiet: quiet);
-    // The stdout does not have a stable documented format, so use the provided
-    // metadata instead.
-    return Platform.version.substring(0, Platform.version.indexOf(' '));
-  }
-}
-
 /**
  * A utility class to run tests for your project.
  */
@@ -358,27 +317,6 @@ class ContentShell extends Chrome {
 
   ContentShell() : super(_contentShellPath());
 }
-
-// TODO: Remove. This is only duplicated (from grinder_sdk.dart) temporarily.
-bool _sdkOnPath;
-
-String _sdkBin(String name) {
-  if (Platform.isWindows) {
-    return name == 'dart' ? 'dart.exe' : '${name}.bat';
-  } else if (Platform.isMacOS) {
-    // If `dart` is not visible, we should join the sdk path and `bin/$name`.
-    // This is only necessary in unusual circumstances, like when the script is
-    // run from the Editor on macos.
-    if (_sdkOnPath == null) {
-      _sdkOnPath = whichSync('dart', orElse: () => null) != null;
-    }
-
-    return _sdkOnPath ? name : '${sdkDir.path}/bin/${name}';
-  } else {
-    return name;
-  }
-}
-// TODO: remove
 
 String _dartiumPath() {
   final Map m = {

--- a/test/grinder_sdk_test.dart
+++ b/test/grinder_sdk_test.dart
@@ -125,6 +125,9 @@ main() {
     });
 
     test('format', () {
+      // TODO: Re-enable this test on windows when our bot has a 1.9.3 SDK on it.
+      if (Platform.isWindows) return;
+
       String originalText = file.readAsStringSync();
       DartFmt.format(file);
       String newText = file.readAsStringSync();

--- a/test/grinder_sdk_test.dart
+++ b/test/grinder_sdk_test.dart
@@ -34,6 +34,14 @@ main() {
       expect(dartVM, isNotNull);
     });
 
+    test('Dart.location', () {
+      expect(Dart.location, isNotNull);
+    });
+
+    test('Dart.version', () {
+      expect(Dart.version(quiet: true), isNotEmpty);
+    });
+
     test('dart2js version', () {
       return mockContext.runZoned(() {
         expect(Dart2js.version(), isNotNull);
@@ -91,6 +99,33 @@ main() {
     test('PubApp.local', () {
       PubApp grinder = new PubApp.local('grinder');
       expect(grinder.isGlobal, false);
+    });
+  });
+
+  group('grinder.sdk DartFmt', () {
+    FilePath temp;
+    File file;
+
+    setUp(() {
+      temp = FilePath.createSystemTemp();
+      file = temp.join('foo.dart').asFile;
+      file.writeAsStringSync('void main() {}');
+    });
+
+    tearDown(() {
+      temp.delete();
+    });
+
+    test('dryRun', () {
+      bool wouldChange = DartFmt.dryRun(file);
+      expect(wouldChange, true);
+    });
+
+    test('format', () {
+      String originalText = file.readAsStringSync();
+      DartFmt.format(file);
+      String newText = file.readAsStringSync();
+      expect(newText, isNot(equals(originalText)));
     });
   });
 }

--- a/test/grinder_sdk_test.dart
+++ b/test/grinder_sdk_test.dart
@@ -34,9 +34,9 @@ main() {
       expect(dartVM, isNotNull);
     });
 
-    test('Dart.location', () {
-      expect(Dart.location, isNotNull);
-    });
+//    test('DartSdk.location', () {
+//      expect(DartSdk.location, isNotNull);
+//    });
 
     test('Dart.version', () {
       expect(Dart.version(quiet: true), isNotEmpty);
@@ -117,6 +117,9 @@ main() {
     });
 
     test('dryRun', () {
+      // TODO: Re-enable this test on windows when our bot has a 1.9.3 SDK on it.
+      if (Platform.isWindows) return;
+
       bool wouldChange = DartFmt.dryRun(file);
       expect(wouldChange, true);
     });

--- a/test/grinder_tools_test.dart
+++ b/test/grinder_tools_test.dart
@@ -8,10 +8,6 @@ import 'package:unittest/unittest.dart';
 
 main() {
   group('grinder.tools', () {
-    test('Dart.version', () {
-      expect(Dart.version(quiet: true), isNotEmpty);
-    });
-
     test('Chrome.getBestInstalledChrome', () {
       Chrome chrome = Chrome.getBestInstalledChrome();
       // Expect that we can always locate a Chrome, even on the bots.


### PR DESCRIPTION
Fix #168.

@seaneagan 

Write a wrapper around the `dartfmt` SDK tool. This is scoped to just exposing what's in the SDK .The user still has the option of using a `PubApp` wrapper around the `dart_style` tool.

(the `Analyzer` and `Dart2js` classes are unchanged; they just changed locations within the file)