### PR TITLE
use the mock context to improve testing

### DIFF
--- a/lib/grinder.dart
+++ b/lib/grinder.dart
@@ -60,9 +60,9 @@ void task(String name, [Function taskFunction, List<String> depends = const []])
 
 /// Run the grinder file.
 ///
-/// First, discovers the tasks declared in your grinder file.  Then, handles
-/// the command-line [args] either by running tasks or responding to
-/// recognized options such as --help.
+/// First, discovers the tasks declared in your grinder file. Then, handles the
+/// command-line [args] either by running tasks or responding to recognized
+/// options such as --help.
 ///
 /// If [verifyProjectRoot] is true, grinder will verify that the script is being
 /// run from a project root.
@@ -74,8 +74,7 @@ Future grind(List<String> args, {bool verifyProjectRoot: true}) {
     return handleArgs(args, verifyProjectRoot: verifyProjectRoot);
   } catch (e) {
     if (e is GrinderException) {
-      stdout.writeln(e.message);
-      exit(1);
+      fail(e.message);
     } else {
       return new Future.error(e);
     }
@@ -101,10 +100,7 @@ GrinderContext get context => zonedContext.value;
 void log(String message) => context.log(message);
 
 /// Halt task execution; throws an exception with the given error message.
-void fail(String message) {
-  log('failed: ${message}');
-  throw new GrinderException(message);
-}
+void fail(String message) => context.fail(message);
 
 /**
  * A [GrinderContext] is used to give the currently running Grinder task the

--- a/lib/grinder.dart
+++ b/lib/grinder.dart
@@ -17,7 +17,6 @@ export 'src/cli.dart' show grinderArgs;
 
 import 'dart:async';
 import 'dart:mirrors';
-import 'dart:io';
 
 import 'src/discover_tasks.dart';
 import 'src/cli.dart';

--- a/lib/src/cli.dart
+++ b/lib/src/cli.dart
@@ -28,15 +28,15 @@ Future handleArgs(List<String> args, {bool verifyProjectRoot: true}) {
   if (results['version']) {
     const String pubUrl = 'https://pub.dartlang.org/packages/grinder.json';
 
-    print('grinder version ${APP_VERSION}');
+    log('grinder version ${APP_VERSION}');
 
     return httpGet(pubUrl).then((String str) {
       List versions = JSON.decode(str)['versions'];
       if (APP_VERSION != versions.last) {
-        print("Version ${versions.last} is available! Run `pub global activate"
+        log("Version ${versions.last} is available! Run `pub global activate"
             " grinder` to get the latest version.");
       } else {
-        print('grinder is up to date!');
+        log('grinder is up to date!');
       }
     }).catchError((e) => null);
   } else if (results['help'] || results['deps']) {
@@ -55,12 +55,13 @@ Future handleArgs(List<String> args, {bool verifyProjectRoot: true}) {
     Future result = grinder.start(results.rest);
 
     return result.catchError((e, st) {
+      String message;
       if (st != null) {
-        print('\n${e}\n${cleanupStackTrace(st)}');
+        message = '\n${e}\n${cleanupStackTrace(st)}';
       } else {
-        print('\n${e}');
+        message = '\n${e}';
       }
-      exit(1);
+      fail(message);
     });
   }
 
@@ -82,24 +83,24 @@ ArgParser createArgsParser() {
 }
 
 void printUsageAndDeps(ArgParser parser, Grinder grinder) {
-  print('usage: dart ${currentScript()} <options> target1 target2 ...');
-  print('');
-  print('valid options:');
-  print(parser.usage.replaceAll('\n\n', '\n'));
+  log('usage: dart ${currentScript()} <options> target1 target2 ...');
+  log('');
+  log('valid options:');
+  log(parser.usage.replaceAll('\n\n', '\n'));
 
   if (grinder.tasks.isEmpty) {
-    print('');
-    print('no current grinder targets');
+    log('');
+    log('no current grinder targets');
   } else {
     // calculate the dependencies
     grinder.start([], dontRun: true);
 
-    print('');
-    print('targets:');
-    print('');
+    log('');
+    log('targets:');
+    log('');
 
     List<GrinderTask> tasks = grinder.tasks.toList();
-    print(tasks.map((task) {
+    log(tasks.map((task) {
       bool isDefault = grinder.defaultTask == task;
       Iterable<GrinderTask> deps = grinder.getImmediateDependencies(task);
 

--- a/lib/src/singleton.dart
+++ b/lib/src/singleton.dart
@@ -3,6 +3,8 @@
 
 library grinder.src.singleton;
 
+import 'dart:io';
+
 import '../grinder.dart';
 import 'utils.dart';
 
@@ -10,15 +12,14 @@ final Grinder grinder = new Grinder();
 
 final ZonedValue zonedContext = new ZonedValue(new _NoopContext());
 
-// TODO: Move to having the default context fast-fail.
-
 class _NoopContext implements GrinderContext {
   Grinder get grinder => null;
 
   GrinderTask get task => null;
 
   void fail(String message) {
-    throw new GrinderException(message);
+    stderr.writeln(message);
+    exit(1);
   }
 
   void log(String message) => print(message);

--- a/test/grinder_sdk_test.dart
+++ b/test/grinder_sdk_test.dart
@@ -12,12 +12,6 @@ import 'src/_common.dart';
 
 main() {
   group('grinder.sdk', () {
-    MockGrinderContext mockContext;
-
-    setUp(() {
-      mockContext = new MockGrinderContext();
-    });
-
     test('sdkDir', () {
       if (Platform.environment['DART_SDK'] != null) {
         expect(sdkDir, isNotNull);
@@ -42,31 +36,25 @@ main() {
       expect(Dart.version(quiet: true), isNotEmpty);
     });
 
-    test('dart2js version', () {
-      return mockContext.runZoned(() {
-        expect(Dart2js.version(), isNotNull);
-      }).then((_) {
-        expect(mockContext.logBuffer, isNotEmpty);
-        expect(mockContext.isFailed, false);
-      });
+    grinderTest('dart2js version', () {
+      expect(Dart2js.version(), isNotNull);
+    }, (MockGrinderContext ctx) {
+      expect(ctx.logBuffer, isNotEmpty);
+      expect(ctx.isFailed, false);
     });
 
-    test('analyzer version', () {
-      return mockContext.runZoned(() {
-        expect(Analyzer.version(), isNotNull);
-      }).then((_) {
-        expect(mockContext.logBuffer, isNotEmpty);
-        expect(mockContext.isFailed, false);
-      });
+    grinderTest('analyzer version', () {
+      expect(Analyzer.version(), isNotNull);
+    }, (MockGrinderContext ctx) {
+      expect(ctx.logBuffer, isNotEmpty);
+      expect(ctx.isFailed, false);
     });
 
-    test('Pub.version', () {
-      return mockContext.runZoned(() {
-        expect(Pub.version(), isNotNull);
-      }).then((_) {
-        expect(mockContext.logBuffer, isNotEmpty);
-        expect(mockContext.isFailed, false);
-      });
+    grinderTest('Pub.version', () {
+      expect(Pub.version(), isNotNull);
+    }, (ctx) {
+      expect(ctx.logBuffer, isNotEmpty);
+      expect(ctx.isFailed, false);
     });
 
     // See #166.
@@ -79,12 +67,10 @@ main() {
 //      });
 //    });
 
-    test('Pub.isActivated', () {
-      return mockContext.runZoned(() {
-        expect(Pub.global.isActivated('foo'), false);
-      }).then((_) {
-        expect(mockContext.isFailed, false);
-      });
+    grinderTest('Pub.isActivated', () {
+      expect(Pub.global.isActivated('foo'), false);
+    }, (ctx) {
+      expect(ctx.isFailed, false);
     });
 
     test('PubApp.global', () {

--- a/test/integration_test.dart
+++ b/test/integration_test.dart
@@ -5,7 +5,6 @@ library grinder.integration_test;
 
 import 'package:grinder/grinder.dart';
 import 'package:grinder/src/cli.dart';
-import 'package:grinder/src/singleton.dart';
 import 'package:unittest/unittest.dart';
 
 import 'src/_common.dart';

--- a/test/integration_test.dart
+++ b/test/integration_test.dart
@@ -8,9 +8,9 @@ import 'package:grinder/src/cli.dart';
 import 'package:grinder/src/singleton.dart';
 import 'package:unittest/unittest.dart';
 
-Map ranTasks = {};
+import 'src/_common.dart';
 
-// TODO: I'm not sure these tests add a lot of value.
+Map ranTasks = {};
 
 main() {
   group('integration', () {
@@ -26,15 +26,12 @@ main() {
       _clear();
     });
 
-    test('all ran', () {
-      return handleArgs(['bar']).then((_) {
-        expect(ranTasks['foo'], true);
-        expect(ranTasks['bar'], true);
-      });
-    });
-
-    test('printUsageAndDeps', () {
-      printUsageAndDeps(createArgsParser(), grinder);
+    grinderTest('all ran', () {
+      return handleArgs(['bar']);
+    }, (ctx) {
+      expect(ctx.isFailed, false);
+      expect(ranTasks['foo'], true);
+      expect(ranTasks['bar'], true);
     });
   });
 }

--- a/test/src/_common.dart
+++ b/test/src/_common.dart
@@ -7,6 +7,16 @@ import 'dart:async';
 
 import 'package:grinder/grinder.dart';
 import 'package:grinder/src/singleton.dart';
+import 'package:unittest/unittest.dart';
+
+typedef TestVerification(MockGrinderContext ctx);
+
+void grinderTest(String name, Function setup, TestVerification verify) {
+  test(name, () {
+    MockGrinderContext ctx = new MockGrinderContext();
+    return ctx.runZoned(() => setup()).then((_) => verify(ctx));
+  });
+}
 
 class MockGrinderContext implements GrinderContext {
   Grinder grinder;

--- a/test/src/cli_test.dart
+++ b/test/src/cli_test.dart
@@ -4,12 +4,22 @@
 library grinder.src.cli_test;
 
 import 'package:grinder/src/cli.dart';
+import 'package:grinder/src/singleton.dart';
 import 'package:unittest/unittest.dart';
+
+import '_common.dart';
 
 main() {
   group('cli', () {
     test('cleanupStackTrace', () {
       expect(cleanupStackTrace(_st), _stExpected);
+    });
+
+    grinderTest('printUsageAndDeps', () {
+      printUsageAndDeps(createArgsParser(), grinder);
+    }, (ctx) {
+      expect(ctx.logBuffer.toString(), contains('valid options:'));
+      expect(ctx.isFailed, false);
     });
   });
 }


### PR DESCRIPTION
Make it easier to test using mock contexts. Change our `_NoopContext` to be functional. When testing, we'll replace it with a mock we can verify. When running, it'll do `print`s and `exit`s for us.