### PR TITLE
more terse help output

### DIFF
--- a/lib/src/cli.dart
+++ b/lib/src/cli.dart
@@ -97,18 +97,17 @@ void printUsageAndDeps(ArgParser parser, Grinder grinder) {
 
     log('');
     log('targets:');
-    log('');
 
     List<GrinderTask> tasks = grinder.tasks.toList();
     log(tasks.map((task) {
       bool isDefault = grinder.defaultTask == task;
       Iterable<GrinderTask> deps = grinder.getImmediateDependencies(task);
 
-      String str = '${task}${isDefault ? ' (default)' : ''}\n';
-      if (task.description != null) str += '  ${task.description}\n';
-      if (deps.isNotEmpty) str += '  depends on: ${deps.map((t) => t.toString()).join(' ')}\n';
+      String str = '  ${task}${isDefault ? ' (default)' : ''}\n';
+      if (task.description != null) str += '    ${task.description}\n';
+      if (deps.isNotEmpty) str += '    depends on: ${deps.map((t) => t.toString()).join(' ')}\n';
       return str;
-    }).join('\n'));
+    }).join());
   }
 }
 


### PR DESCRIPTION
Make the help output a bit more compact. From:

```
targets:

[coverage]
  Gather and send coverage data.

[test]

[tests-build-web]

[analyze]

[tests-web]

[check-init]
  Check that the generated `init` grind script analyzes well.

[buildbot] (default)
  depends on: [analyze] [test] [check-init] [coverage]
```

to:

```

targets:
  [coverage]
    Gather and send coverage data.
  [test]
  [tests-build-web]
  [analyze]
  [tests-web]
  [check-init]
    Check that the generated `init` grind script analyzes well.
  [buildbot] (default)
    depends on: [analyze] [test] [check-init] [coverage]
```