### PR TITLE
add `pub downgrade`.

### DIFF
--- a/AUTHORS
+++ b/AUTHORS
@@ -10,3 +10,4 @@ W. Brian Gourlie <bgourlie@gmail.com>
 Kenneth Endfinger <kaendfinger@gmail.com>
 Sean Eagan <seaneagan1@gmail.com>
 Guillermo López-Anglada <guillermo.lopez@outlook.com>
+Günter Zöchbauer <guenter@gzoechbauer.com>

--- a/lib/grinder_sdk.dart
+++ b/lib/grinder_sdk.dart
@@ -138,6 +138,21 @@ class Pub {
   }
 
   /**
+   * Run `pub downgrade` on the current project.
+   */
+  static void downgrade({String workingDirectory}) {
+    _run('downgrade', workingDirectory: workingDirectory);
+  }
+
+  /**
+   * Run `pub downgrade` on the current project.
+   */
+  static Future downgradeAsync({String workingDirectory}) {
+    return run_lib.runAsync(_sdkBin('pub'), arguments: ['downgrade'],
+        workingDirectory: workingDirectory).then((_) => null);
+  }
+
+  /**
    * Run `pub build` on the current project.
    *
    * The valid values for [mode] are `release` and `debug`.


### PR DESCRIPTION
I want to run my tests twice to check whether the lower bounds of my dependencies are still appropriate.

```dart
_test() {
  Pub.downgrade();
  new PubApp.local('test').run(['-rexpanded']);
  Pub.upgrade();
  new PubApp.local('test').run(['-rexpanded']);
}
```