### PR TITLE
remove the vm memory options

### DIFF
--- a/changelog.md
+++ b/changelog.md
@@ -6,6 +6,7 @@
 - Introduce `RunOptions` to support all `Process.run`/`Process.start` 
   parameters. The `workingDirectory` parameter is now deprecated in all methods, 
   use `RunOptions.workingDirectory` instead.
+- In `Dart.run`, deprecate the vmNewGenHeapMB and vmOldGenHeapMB options.
 
 ## 0.7.0
 - Big changes! Task definititions are now primarily annotation based; see the

--- a/lib/grinder_sdk.dart
+++ b/lib/grinder_sdk.dart
@@ -46,8 +46,10 @@ class Dart {
   static String run(String script, {List<String> arguments : const [],
       bool quiet: false, String packageRoot, RunOptions runOptions,
       @Deprecated('Use RunOptions.workingDirectory instead.')
-      String workingDirectory, int vmNewGenHeapMB,
-       int vmOldGenHeapMB, List<String> vmArgs : const []}) {
+      String workingDirectory,
+      @deprecated int vmNewGenHeapMB,
+      @deprecated int vmOldGenHeapMB,
+      List<String> vmArgs : const []}) {
     runOptions = mergeWorkingDirectory(workingDirectory, runOptions);
     List<String> args = [];
 
@@ -55,14 +57,6 @@ class Dart {
 
     if (packageRoot != null) {
       args.add('--package-root=${packageRoot}');
-    }
-
-    if (vmNewGenHeapMB != null) {
-      args.add('--new_gen_heap_size=${vmNewGenHeapMB}');
-    }
-
-    if (vmOldGenHeapMB != null) {
-      args.add('--old_gen_heap_size=${vmOldGenHeapMB}');
     }
 
     args.add(script);

--- a/lib/grinder_tools.dart
+++ b/lib/grinder_tools.dart
@@ -35,7 +35,9 @@ final Directory webDir = new Directory('web');
 @Deprecated('Use `Dart.run` instead.')
 String runDartScript(String script,
     {List<String> arguments : const [], bool quiet: false, String packageRoot,
-    RunOptions runOptions, int vmNewGenHeapMB, int vmOldGenHeapMB,
+    RunOptions runOptions,
+    @deprecated int vmNewGenHeapMB,
+    @deprecated int vmOldGenHeapMB,
     @Deprecated('Use RunOptions.workingDirectory instead.')
     String workingDirectory}) {
   runOptions = mergeWorkingDirectory(workingDirectory, runOptions);


### PR DESCRIPTION
Deprecate the `vmNewGenHeapMB` and `vmOldGenHeapMB` vm options. `--new_gen_heap_size` is no longer available, and `--old_gen_heap_size` is I think not as needed.

@seaneagan 