### PR TITLE
add a `format` task to tool/grind.dart

### DIFF
--- a/changelog.md
+++ b/changelog.md
@@ -8,7 +8,7 @@
   use `RunOptions.workingDirectory` instead.
 - Added `PubApp.runAsync`.
 - In `Dart.run`, deprecate the vmNewGenHeapMB and vmOldGenHeapMB options.
-- Support to pass lists of files or directories to `DartFmt.format()`
+- Support for passing lists of files or directories to `DartFmt.format()`
 
 ## 0.7.0
 - Big changes! Task definititions are now primarily annotation based; see the

--- a/changelog.md
+++ b/changelog.md
@@ -8,6 +8,7 @@
   use `RunOptions.workingDirectory` instead.
 - Added `PubApp.runAsync`.
 - In `Dart.run`, deprecate the vmNewGenHeapMB and vmOldGenHeapMB options.
+- Support to pass lists of files or directories to `DartFmt.format()`
 
 ## 0.7.0
 - Big changes! Task definititions are now primarily annotation based; see the

--- a/lib/grinder_sdk.dart
+++ b/lib/grinder_sdk.dart
@@ -326,28 +326,17 @@ class DartFmt {
   /// Run the `dartfmt` command with the `--overwrite` option. Format a file, a
   /// directory or a list of files or directories in place.
   static void format(fileOrPath) {
-    if (fileOrPath is File) {
-      fileOrPath = fileOrPath.path;
-    }
-    if (fileOrPath is List) {
-      _run('--overwrite', fileOrPath);
-    } else {
-      _run('--overwrite', [fileOrPath]);
-    }
+    if (fileOrPath is File) fileOrPath = fileOrPath.path;
+    if (fileOrPath is! List) fileOrPath = [fileOrPath];
+    _run('--overwrite', fileOrPath);
   }
 
   /// Run the `dartfmt` command with the `--dry-run` option. Return `true` if
   /// any files would be changed by running the formatter.
   static bool dryRun(fileOrPath) {
-    String results;
-    if (fileOrPath is File) {
-      fileOrPath = fileOrPath.path;
-    }
-    if (fileOrPath is List) {
-      results = _run('--dry-run', fileOrPath);
-    } else {
-      results = _run('--dry-run', [fileOrPath]);
-    }
+    if (fileOrPath is File) fileOrPath = fileOrPath.path;
+    if (fileOrPath is! List) fileOrPath = [fileOrPath];
+    String results = _run('--dry-run', fileOrPath);
     return results.trim().isNotEmpty;
   }
 

--- a/lib/grinder_sdk.dart
+++ b/lib/grinder_sdk.dart
@@ -323,24 +323,37 @@ class Analyzer {
 /// Utility class for invoking `dartfmt` from the SDK. This wrapper requires
 /// the `dartfmt` from SDK 1.9 and greater.
 class DartFmt {
-  /// Run the `dartfmt` command with the `--overwrite` option. Format any files
-  /// in place.
+  /// Run the `dartfmt` command with the `--overwrite` option. Format a file, a
+  /// directory or a list of files or directories in place.
   static void format(fileOrPath) {
-    if (fileOrPath is File) fileOrPath = fileOrPath.path;
-    _run('--overwrite', fileOrPath);
+    if (fileOrPath is File) {
+      fileOrPath = fileOrPath.path;
+    }
+    if (fileOrPath is List) {
+      _run('--overwrite', fileOrPath);
+    } else {
+      _run('--overwrite', [fileOrPath]);
+    }
   }
 
   /// Run the `dartfmt` command with the `--dry-run` option. Return `true` if
   /// any files would be changed by running the formatter.
   static bool dryRun(fileOrPath) {
-    if (fileOrPath is File) fileOrPath = fileOrPath.path;
-    String results = _run('--dry-run', fileOrPath);
+    String results;
+    if (fileOrPath is File) {
+      fileOrPath = fileOrPath.path;
+    }
+    if (fileOrPath is List) {
+      results = _run('--dry-run', fileOrPath);
+    } else {
+      results = _run('--dry-run', [fileOrPath]);
+    }
     return results.trim().isNotEmpty;
   }
 
-  static String _run(String option, String target, {bool quiet: false}) =>
-      run_lib.run(_sdkBin('dartfmt'),
-          quiet: quiet, arguments: [option, target]);
+  static String _run(String option, List<String> targets,
+      {bool quiet: false}) => run_lib.run(_sdkBin('dartfmt'),
+          quiet: quiet, arguments: [option]..addAll(targets));
 }
 
 /// Access the `pub global` commands.

--- a/tool/grind.dart
+++ b/tool/grind.dart
@@ -68,3 +68,14 @@ Future testsBuildWeb() {
     return Tests.runWebTests(directory: 'build/web', htmlFile: 'web.html');
   });
 }
+
+const sourceDirectories = const [
+  'bin',
+  'example',
+  'lib',
+  'test',
+  'tool',
+  'web'
+];
+@Task('Apply dartformat oo all Dart source files')
+format() => DartFmt.format(sourceDirectories);

--- a/tool/grind.dart
+++ b/tool/grind.dart
@@ -77,5 +77,5 @@ const sourceDirectories = const [
   'tool',
   'web'
 ];
-@Task('Apply dartformat oo all Dart source files')
+@Task('Apply dartformat to all Dart source files')
 format() => DartFmt.format(sourceDirectories);


### PR DESCRIPTION
With the now formatted Dart code it would make sense to add a `format` task to keep the code formatted.
I don't know if you want it added to the default task.

I prefer passing a concrete list of directories to `dartfmt` because for example with `.` `dartfmt` also formats the `build` directory, if there is any, which then also contains a copy of all dependencies which can make it quite a lengthy but pointless task.
