### PR TITLE
Devoncarew test 0 12 0

### DIFF
--- a/changelog.md
+++ b/changelog.md
@@ -10,6 +10,7 @@
 - In `Dart.run`, deprecate the vmNewGenHeapMB and vmOldGenHeapMB options.
 - Added support for passing lists of files or directories to `DartFmt.format()`.
 - `Analyzer.analyzeFiles` is deprecated in favor of `Analyzer.analyze`.
+- added a `TestRunner` class - a wrapper around the new `test` package.
 
 ## 0.7.0 (2015/4/20)
 - Big changes! Task definitions are now primarily annotation based; see the

--- a/lib/grinder_tools.dart
+++ b/lib/grinder_tools.dart
@@ -61,6 +61,7 @@ void defaultClean([GrinderContext context]) => delete(buildDir);
 /**
  * A utility class to run tests for your project.
  */
+@Deprecated('see `Test`')
 class Tests {
   /**
    * Run command-line tests. You can specify the base directory (`test`), and
@@ -172,6 +173,58 @@ class Tests {
 
       return completer.future;
     });
+  }
+}
+
+/// A wrapper around the `test` package. This class is used to run your unit
+/// tests.
+class Test {
+  final PubApp _test = new PubApp.local('test');
+
+  Test();
+
+  /// Run the tests in the current package. See
+  /// https://pub.dartlang.org/packages/test.
+  ///
+  /// [name] is substring of the name of the test to run. Regular expression
+  /// syntax is supported. [plainName] is a plain-text substring of the name of
+  /// the test to run. [platform] is the platform(s) on which to run the tests.
+  /// Available values are `vm` (default), `dartium`, `content-shell`, `chrome`,
+  /// `phantomjs`, `firefox`, `safari`. [concurrency] controls the number of
+  /// concurrent test suites run (defaults to 4). [pubServe] is the port of a
+  /// pub serve instance serving `test/`.
+  void test({String name, String plainName, List<String> platforms,
+      int concurrency, int pubServe, RunOptions runOptions}) {
+    List<String>args = ['--reporter=expanded'];
+    if (name != null) args.add('--name=${name}');
+    if (plainName != null) args.add('--plain-name=${plainName}');
+    if (platforms != null) args.add('--platform=${platforms.join(',')}');
+    if (concurrency != null) args.add('--concurrency=${concurrency}');
+    if (pubServe != null) args.add('--pub-serve=${pubServe}');
+    _test.run(args, script: 'test', runOptions: runOptions);
+  }
+
+  /// Run the tests in the current package. See
+  /// https://pub.dartlang.org/packages/test.
+  ///
+  /// [name] is substring of the name of the test to run. Regular expression
+  /// syntax is supported. [plainName] is a plain-text substring of the name of
+  /// the test to run. [platform] is the platform(s) on which to run the tests.
+  /// Available values are `vm` (default), `dartium`, `content-shell`, `chrome`,
+  /// `phantomjs`, `firefox`, `safari`. [concurrency] controls the number of
+  /// concurrent test suites run (defaults to 4). [pubServe] is the port of a
+  /// pub serve instance serving `test/`. [color] controls whether the test
+  /// output uses ANSI colors.
+  Future testAsync({String name, String plainName, List<String> platforms,
+      int concurrency, int pubServe, bool color, RunOptions runOptions}) {
+    List<String>args = ['--reporter=expanded'];
+    if (name != null) args.add('--name=${name}');
+    if (plainName != null) args.add('--plain-name=${plainName}');
+    if (platforms != null) args.add('--platform=${platforms.join(',')}');
+    if (concurrency != null) args.add('--concurrency=${concurrency}');
+    if (pubServe != null) args.add('--pub-serve=${pubServe}');
+    if (color != null) args.add(color ? '--color' : '--no-color');
+    return _test.runAsync(args, script: 'test', runOptions: runOptions);
   }
 }
 

--- a/lib/grinder_tools.dart
+++ b/lib/grinder_tools.dart
@@ -197,10 +197,12 @@ class TestRunner {
   /// serving `test/`.
   void test({String name, String plainName, dynamic platformSelector,
       int concurrency, int pubServe, RunOptions runOptions}) {
-    _test.run(
-        _buildArgs(name: name, plainName: plainName, platformSelector: platformSelector,
-                   concurrency: concurrency, pubServe: pubServe),
-        script: 'test', runOptions: runOptions);
+    _test.run(_buildArgs(
+        name: name,
+        plainName: plainName,
+        selector: platformSelector,
+        concurrency: concurrency,
+        pubServe: pubServe), script: 'test', runOptions: runOptions);
   }
 
   /// Run the tests in the current package. See the
@@ -217,20 +219,22 @@ class TestRunner {
   /// serving `test/`.
   Future testAsync({String name, String plainName, dynamic platformSelector,
       int concurrency, int pubServe, RunOptions runOptions}) {
-    return _test.runAsync(
-        _buildArgs(name: name, plainName: plainName, platformSelector: platformSelector,
-                   concurrency: concurrency, pubServe: pubServe),
-        script: 'test', runOptions: runOptions);
+    return _test.runAsync(_buildArgs(
+        name: name,
+        plainName: plainName,
+        selector: platformSelector,
+        concurrency: concurrency,
+        pubServe: pubServe), script: 'test', runOptions: runOptions);
   }
 
-  List<String> _buildArgs({String name, String plainName,
-      dynamic platformSelector, int concurrency, int pubServe}) {
+  List<String> _buildArgs({String name, String plainName, dynamic selector,
+      int concurrency, int pubServe}) {
     List<String> args = ['--reporter=expanded'];
     if (name != null) args.add('--name=${name}');
     if (plainName != null) args.add('--plain-name=${plainName}');
-    if (platformSelector != null) {
-      if (platformSelector is List) platformSelector = platformSelector.join('||');
-      args.add('--platform=${platformSelector}');
+    if (selector != null) {
+      if (selector is List) selector = selector.join('||');
+      args.add('--platform=${selector}');
     }
     if (concurrency != null) args.add('--concurrency=${concurrency}');
     if (pubServe != null) args.add('--pub-serve=${pubServe}');

--- a/lib/grinder_tools.dart
+++ b/lib/grinder_tools.dart
@@ -195,7 +195,7 @@ class Test {
   /// pub serve instance serving `test/`.
   void test({String name, String plainName, List<String> platforms,
       int concurrency, int pubServe, RunOptions runOptions}) {
-    List<String>args = ['--reporter=expanded'];
+    List<String> args = ['--reporter=expanded'];
     if (name != null) args.add('--name=${name}');
     if (plainName != null) args.add('--plain-name=${plainName}');
     if (platforms != null) args.add('--platform=${platforms.join(',')}');
@@ -217,7 +217,7 @@ class Test {
   /// output uses ANSI colors.
   Future testAsync({String name, String plainName, List<String> platforms,
       int concurrency, int pubServe, bool color, RunOptions runOptions}) {
-    List<String>args = ['--reporter=expanded'];
+    List<String> args = ['--reporter=expanded'];
     if (name != null) args.add('--name=${name}');
     if (plainName != null) args.add('--plain-name=${plainName}');
     if (platforms != null) args.add('--platform=${platforms.join(',')}');

--- a/lib/grinder_tools.dart
+++ b/lib/grinder_tools.dart
@@ -61,7 +61,7 @@ void defaultClean([GrinderContext context]) => delete(buildDir);
 /**
  * A utility class to run tests for your project.
  */
-@Deprecated('see `Test`')
+@Deprecated('see [TestRunner]')
 class Tests {
   /**
    * Run command-line tests. You can specify the base directory (`test`), and
@@ -178,53 +178,64 @@ class Tests {
 
 /// A wrapper around the `test` package. This class is used to run your unit
 /// tests.
-class Test {
+class TestRunner {
   final PubApp _test = new PubApp.local('test');
 
-  Test();
+  TestRunner();
 
-  /// Run the tests in the current package. See
-  /// https://pub.dartlang.org/packages/test.
+  /// Run the tests in the current package. See the
+  /// [test package](https://pub.dartlang.org/packages/test).
   ///
   /// [name] is substring of the name of the test to run. Regular expression
   /// syntax is supported. [plainName] is a plain-text substring of the name of
-  /// the test to run. [platform] is the platform(s) on which to run the tests.
-  /// Available values are `vm` (default), `dartium`, `content-shell`, `chrome`,
-  /// `phantomjs`, `firefox`, `safari`. [concurrency] controls the number of
-  /// concurrent test suites run (defaults to 4). [pubServe] is the port of a
-  /// pub serve instance serving `test/`.
-  void test({String name, String plainName, List<String> platforms,
+  /// the test to run. [platformSelector] is the platform(s) on which to run the
+  /// tests. This parameter can be a String or a List.
+  /// [Available values](https://github.com/dart-lang/test#platform-selector-syntax)
+  /// are `vm` (default), `dartium`, `content-shell`, `chrome`, `phantomjs`,
+  /// `firefox`, `safari`. [concurrency] controls the number of concurrent test
+  /// suites run (defaults to 4). [pubServe] is the port of a pub serve instance
+  /// serving `test/`.
+  void test({String name, String plainName, dynamic platformSelector,
       int concurrency, int pubServe, RunOptions runOptions}) {
-    List<String> args = ['--reporter=expanded'];
-    if (name != null) args.add('--name=${name}');
-    if (plainName != null) args.add('--plain-name=${plainName}');
-    if (platforms != null) args.add('--platform=${platforms.join(',')}');
-    if (concurrency != null) args.add('--concurrency=${concurrency}');
-    if (pubServe != null) args.add('--pub-serve=${pubServe}');
-    _test.run(args, script: 'test', runOptions: runOptions);
+    _test.run(
+        _buildArgs(name: name, plainName: plainName, platformSelector: platformSelector,
+                   concurrency: concurrency, pubServe: pubServe),
+        script: 'test', runOptions: runOptions);
   }
 
-  /// Run the tests in the current package. See
-  /// https://pub.dartlang.org/packages/test.
+  /// Run the tests in the current package. See the
+  /// [test package](https://pub.dartlang.org/packages/test).
   ///
   /// [name] is substring of the name of the test to run. Regular expression
   /// syntax is supported. [plainName] is a plain-text substring of the name of
-  /// the test to run. [platform] is the platform(s) on which to run the tests.
-  /// Available values are `vm` (default), `dartium`, `content-shell`, `chrome`,
-  /// `phantomjs`, `firefox`, `safari`. [concurrency] controls the number of
-  /// concurrent test suites run (defaults to 4). [pubServe] is the port of a
-  /// pub serve instance serving `test/`. [color] controls whether the test
-  /// output uses ANSI colors.
-  Future testAsync({String name, String plainName, List<String> platforms,
-      int concurrency, int pubServe, bool color, RunOptions runOptions}) {
+  /// the test to run. [platformSelector] is the platform(s) on which to run the
+  /// tests. This parameter can be a String or a List.
+  /// [Available values](https://github.com/dart-lang/test#platform-selector-syntax)
+  /// are `vm` (default), `dartium`, `content-shell`, `chrome`, `phantomjs`,
+  /// `firefox`, `safari`. [concurrency] controls the number of concurrent test
+  /// suites run (defaults to 4). [pubServe] is the port of a pub serve instance
+  /// serving `test/`.
+  Future testAsync({String name, String plainName, dynamic platformSelector,
+      int concurrency, int pubServe, RunOptions runOptions}) {
+    return _test.runAsync(
+        _buildArgs(name: name, plainName: plainName, platformSelector: platformSelector,
+                   concurrency: concurrency, pubServe: pubServe),
+        script: 'test', runOptions: runOptions);
+  }
+
+  List<String> _buildArgs({String name, String plainName,
+      dynamic platformSelector, int concurrency, int pubServe}) {
     List<String> args = ['--reporter=expanded'];
     if (name != null) args.add('--name=${name}');
     if (plainName != null) args.add('--plain-name=${plainName}');
-    if (platforms != null) args.add('--platform=${platforms.join(',')}');
+    if (platformSelector != null) {
+      if (platformSelector is List) platformSelector = platformSelector.join('||');
+      args.add('--platform=${platformSelector}');
+    }
     if (concurrency != null) args.add('--concurrency=${concurrency}');
     if (pubServe != null) args.add('--pub-serve=${pubServe}');
-    if (color != null) args.add(color ? '--color' : '--no-color');
-    return _test.runAsync(args, script: 'test', runOptions: runOptions);
+    // TODO: Pass in --color based on a global property: #243.
+    return args;
   }
 }
 

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -23,6 +23,7 @@ dependencies:
 
 dev_dependencies:
   browser: any
+  test: '^0.12.0'
   unittest: '^0.11.0'
 
 executables:

--- a/test/grinder_files_test.dart
+++ b/test/grinder_files_test.dart
@@ -6,7 +6,7 @@ library grinder.files_test;
 import 'dart:io';
 
 import 'package:grinder/grinder.dart';
-import 'package:unittest/unittest.dart';
+import 'package:test/test.dart';
 
 final String _sep = Platform.pathSeparator;
 

--- a/test/grinder_sdk_test.dart
+++ b/test/grinder_sdk_test.dart
@@ -6,7 +6,7 @@ library grinder.sdk_test;
 import 'dart:io';
 
 import 'package:grinder/grinder.dart';
-import 'package:unittest/unittest.dart';
+import 'package:test/test.dart';
 
 import 'src/_common.dart';
 

--- a/test/grinder_test.dart
+++ b/test/grinder_test.dart
@@ -6,7 +6,7 @@ library grinder_test;
 import 'dart:async';
 
 import 'package:grinder/grinder.dart' hide fail;
-import 'package:unittest/unittest.dart';
+import 'package:test/test.dart';
 
 main() {
   group('grinder', () {

--- a/test/grinder_tools_test.dart
+++ b/test/grinder_tools_test.dart
@@ -4,7 +4,7 @@
 library grinder.tools_test;
 
 import 'package:grinder/grinder.dart';
-import 'package:unittest/unittest.dart';
+import 'package:test/test.dart';
 
 main() {
   group('grinder.tools', () {

--- a/test/integration_test.dart
+++ b/test/integration_test.dart
@@ -5,7 +5,7 @@ library grinder.integration_test;
 
 import 'package:grinder/grinder.dart';
 import 'package:grinder/src/cli.dart';
-import 'package:unittest/unittest.dart';
+import 'package:test/test.dart';
 
 import 'src/_common.dart';
 

--- a/test/src/_common.dart
+++ b/test/src/_common.dart
@@ -7,7 +7,7 @@ import 'dart:async';
 
 import 'package:grinder/grinder.dart';
 import 'package:grinder/src/singleton.dart';
-import 'package:unittest/unittest.dart';
+import 'package:test/test.dart';
 
 typedef TestVerification(MockGrinderContext ctx);
 

--- a/test/src/cli_test.dart
+++ b/test/src/cli_test.dart
@@ -3,9 +3,9 @@
 
 library grinder.src.cli_test;
 
-import 'package:grinder/src/cli.dart';
-import 'package:unittest/unittest.dart';
 import 'package:grinder/grinder.dart';
+import 'package:grinder/src/cli.dart';
+import 'package:test/test.dart';
 
 main() {
   group('cli', () {

--- a/test/src/discover_tasks_test.dart
+++ b/test/src/discover_tasks_test.dart
@@ -7,7 +7,7 @@ import 'dart:mirrors';
 
 import 'package:grinder/grinder.dart';
 import 'package:grinder/src/discover_tasks.dart';
-import 'package:unittest/unittest.dart';
+import 'package:test/test.dart';
 
 import 'task_discovery/good_tasks.dart' as good;
 import 'task_discovery/bad_tasks.dart' as bad;

--- a/test/src/run_test.dart
+++ b/test/src/run_test.dart
@@ -5,10 +5,11 @@ library grinder.test.src.run;
 
 import 'dart:io' as io;
 
+import 'dart:convert' show Converter, Encoding, JSON;
+
 import 'package:grinder/grinder.dart';
 import 'package:grinder/grinder_tools.dart';
-import 'package:unittest/unittest.dart';
-import 'dart:convert' show Converter, Encoding, JSON;
+import 'package:test/test.dart';
 
 final String sep = io.Platform.pathSeparator;
 const runScriptName = 'run_script.dart';

--- a/test/src/utils_test.dart
+++ b/test/src/utils_test.dart
@@ -4,7 +4,7 @@
 library grinder.src.utils_test;
 
 import 'package:grinder/src/utils.dart';
-import 'package:unittest/unittest.dart';
+import 'package:test/test.dart';
 
 main() {
   group('src.utils', () {

--- a/tool/grind.dart
+++ b/tool/grind.dart
@@ -9,12 +9,10 @@ import 'package:grinder/grinder.dart';
 main(args) => grind(args);
 
 @Task()
-void analyze() {
-  new PubApp.global('tuneup')..run(['check', '--ignore-infos']);
-}
+analyze() => new PubApp.global('tuneup')..runAsync(['check', '--ignore-infos']);
 
 @Task()
-test() => Tests.runCliTests();
+test() => new Test().testAsync();
 
 @Task('Apply dartfmt to all Dart source files')
 format() => DartFmt.format(['bin', 'example', 'lib', 'test', 'tool', 'web']);

--- a/tool/grind.dart
+++ b/tool/grind.dart
@@ -12,7 +12,7 @@ main(args) => grind(args);
 analyze() => new PubApp.global('tuneup')..runAsync(['check', '--ignore-infos']);
 
 @Task()
-test() => new Test().testAsync();
+test() => new TestRunner().testAsync();
 
 @Task('Apply dartfmt to all Dart source files')
 format() => DartFmt.format(['bin', 'example', 'lib', 'test', 'tool', 'web']);

--- a/web/web.dart
+++ b/web/web.dart
@@ -6,7 +6,7 @@ library grinder.web_test;
 import 'dart:async';
 
 import 'package:grinder/src/webtest.dart';
-import 'package:unittest/unittest.dart';
+import 'package:test/test.dart';
 
 void main() {
   // Set up the test environment.


### PR DESCRIPTION
fix #217 
fix #58 

- add a wrapper for the `test` package, called `Test`
- deprecate the `Tests` class
- import both `test` and `unittest` so we can deprecate functionality before removing it
- switch our unit tests over to using `test` and dogfood `Test` in our build script

@seaneagan 