### PR TITLE
rev to 0.9.0-nullsafety.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,9 +1,9 @@
 # grinder.dart changes
 
-## 0.8.7-nullsafety.1
+## 0.9.0-nullsafety.0
+- Support null-safety.
 - Declare `Never` instead of `Null` for `fail()` and `GrinderContext.fail()`.
 - Make the `args` parameter to `GrinderTask.execute()` optional.
-- Support null-safety mode.
 
 ## 0.8.6
 - Declare a `Null` return type for `fail()` and `GrinderContext.fail()`.

--- a/lib/src/cli.dart
+++ b/lib/src/cli.dart
@@ -13,7 +13,7 @@ import 'cli_util.dart';
 import 'singleton.dart' as singleton;
 
 // This version must be updated in tandem with the pubspec version.
-const String appVersion = '0.8.5';
+const String appVersion = '0.9.0-nullsafety.0';
 
 List<String> grinderArgs() {
   if (_args == null) fail('grinderArgs() may only be called after grind().');

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,6 +1,6 @@
 name: grinder
 # This version must be updated in tandem with the lib/src/cli.dart version.
-version: 0.8.7-nullsafety.1
+version: 0.9.0-nullsafety.0
 description: Grinder is a task runner for Dart, helping to define and automate common project workflows.
 
 homepage: https://github.com/google/grinder.dart


### PR DESCRIPTION
- rev to 0.9.0-nullsafety.0 to prep for publishing the null safe version
- related to https://github.com/google/grinder.dart/issues/369
