### PR TITLE
update grinder dependency to the current

### DIFF
--- a/tool/grind.dart
+++ b/tool/grind.dart
@@ -31,7 +31,8 @@ environment:
   sdk: '>=2.10.0 <3.0.0'
 
 dependencies:
-  grinder: ^0.8.6
+  grinder:
+    path: ${FilePath.current.path}
 ''', flush: true);
     Dart.run(FilePath.current.join('bin', 'init.dart').path,
         runOptions: RunOptions(workingDirectory: temp.path));


### PR DESCRIPTION
I send a pr about fixing `check-init` (https://github.com/google/grinder.dart/pull/375) grinder task, however the grinder dependency is not reference the current grinder project. So I make a patch about this.