### PR TITLE
cmd line too long error on Windows

### DIFF
--- a/lib/grinder_sdk.dart
+++ b/lib/grinder_sdk.dart
@@ -368,7 +368,7 @@ class Analyzer {
       'analyze',
       if (packageRoot != null) '--package-root=${packageRoot.path}',
       if (fatalWarnings) '--fatal-warnings',
-      ...findDartSourceFiles(coerceToPathList(fileOrPaths))
+      fileOrPaths
     ]);
   }
 


### PR DESCRIPTION
Hi there,

On the Windows platform the grinder `analyze` task generates a "command line too long" error on Windows when there is a large number of files to analyze, since the code attempts to list all files that will be analyzed, rather then a folder name (it that's what has been provided  This PR resolves the issue on Windows, and I expect will not affect other platforms.