### PR TITLE
Support cli_util 0.5.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,7 +1,8 @@
-## 0.9.6-wip
+## 0.9.6
 
 - Update the SDK constraint to 3.1.
 - Update to package:lints 4.0.0.
+- Support package:cli_util 0.5.0.
 
 ## 0.9.5
 

--- a/lib/src/cli.dart
+++ b/lib/src/cli.dart
@@ -13,7 +13,7 @@ import 'cli_util.dart';
 import 'singleton.dart' as singleton;
 
 // This version must be updated in tandem with the pubspec version.
-const String appVersion = '0.9.6-wip';
+const String appVersion = '0.9.6';
 
 List<String> grinderArgs() {
   if (_args == null) fail('grinderArgs() may only be called after grind().');

--- a/lib/src/cli.dart
+++ b/lib/src/cli.dart
@@ -13,7 +13,7 @@ import 'cli_util.dart';
 import 'singleton.dart' as singleton;
 
 // This version must be updated in tandem with the pubspec version.
-const String appVersion = '0.9.6';
+const String appVersion = '0.9.6-dev';
 
 List<String> grinderArgs() {
   if (_args == null) fail('grinderArgs() may only be called after grind().');

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,6 +1,6 @@
 name: grinder
 # This version must be updated in tandem with the lib/src/cli.dart version.
-version: 0.9.6-wip
+version: 0.9.6
 description: >-
   Grinder is a task runner for Dart, helping to define and automate common
   project workflows.
@@ -10,7 +10,7 @@ environment:
   sdk: ^3.1.0
 
 dependencies:
-  cli_util: ^0.4.0
+  cli_util: '>=0.4.0 <0.6.0'
   glob: ^2.0.0
   meta: ^1.4.0
   path: ^1.8.0

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,6 +1,6 @@
 name: grinder
 # This version must be updated in tandem with the lib/src/cli.dart version.
-version: 0.9.6
+version: 0.9.6-dev
 description: >-
   Grinder is a task runner for Dart, helping to define and automate common
   project workflows.


### PR DESCRIPTION
Declare support for `cli_util` versions 0.5.x. This package does not use `applicationConfigHome`, so it's not affected by breaking changes and can keep supporting 0.4.x too.